### PR TITLE
fix module name

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -409,28 +409,28 @@ func TestMethod(t *testing.T) {
 	}{
 		{
 			method:     Method(&servicePtr, "Hello"),
-			pkgFull:    "github.com/starius/api2",
+			pkgFull:    "github.com/CyberhavenInc/api2",
 			pkgName:    "api2",
 			structName: "ServiceStruct",
 			methodName: "Hello",
 		},
 		{
 			method:     Method(&servicePtrNil, "Hello"),
-			pkgFull:    "github.com/starius/api2",
+			pkgFull:    "github.com/CyberhavenInc/api2",
 			pkgName:    "api2",
 			structName: "ServiceStruct",
 			methodName: "Hello",
 		},
 		{
 			method:     Method(&serviceInterface, "Hello"),
-			pkgFull:    "github.com/starius/api2",
+			pkgFull:    "github.com/CyberhavenInc/api2",
 			pkgName:    "api2",
 			structName: "ServiceInterface",
 			methodName: "Hello",
 		},
 		{
 			method:     Method(&serviceInterfaceNil, "Hello"),
-			pkgFull:    "github.com/starius/api2",
+			pkgFull:    "github.com/CyberhavenInc/api2",
 			pkgName:    "api2",
 			structName: "ServiceInterface",
 			methodName: "Hello",

--- a/closingclient/closing_client_test.go
+++ b/closingclient/closing_client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 )
 
 func TestClosingClient(t *testing.T) {

--- a/debugclient/debug_client_test.go
+++ b/debugclient/debug_client_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 )
 
 func TestErrToHttp(t *testing.T) {

--- a/example/app/main.go
+++ b/example/app/main.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/starius/api2"
-	"github.com/starius/api2/example"
+	"github.com/CyberhavenInc/api2"
+	"github.com/CyberhavenInc/api2/example"
 )
 
 func main() {

--- a/example/client.go
+++ b/example/client.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 )
 
 type Client struct {

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/starius/api2/example"
+	"github.com/CyberhavenInc/api2/example"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/example/gen/main.go
+++ b/example/gen/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/starius/api2"
-	"github.com/starius/api2/example"
+	"github.com/CyberhavenInc/api2"
+	"github.com/CyberhavenInc/api2/example"
 )
 
 func main() {

--- a/example/routes.go
+++ b/example/routes.go
@@ -3,7 +3,7 @@ package example
 import (
 	"net/http"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 )
 
 func GetRoutes(s IEchoService) []api2.Route {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/starius/api2
+module github.com/CyberhavenInc/api2
 
 go 1.19
 

--- a/openapi_gen.go
+++ b/openapi_gen.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"reflect"
 
+	"github.com/CyberhavenInc/api2/typegen"
 	spec "github.com/getkin/kin-openapi/openapi3"
-	"github.com/starius/api2/typegen"
 )
 
 func GenerateOpenApiSpec(options *TypesGenConfig) {

--- a/test/api_test.go
+++ b/test/api_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 	"go.uber.org/goleak"
 )
 

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 )
 
 func TestAuth(t *testing.T) {

--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 )
 
 func BenchmarkAPI(b *testing.B) {

--- a/test/csv_test.go
+++ b/test/csv_test.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/starius/api2"
-	"github.com/starius/api2/errors"
+	"github.com/CyberhavenInc/api2"
+	"github.com/CyberhavenInc/api2/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/test/ctx_test.go
+++ b/test/ctx_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 )
 
 func TestCtx(t *testing.T) {

--- a/test/custom_error_test.go
+++ b/test/custom_error_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 )
 
 type MyError struct {

--- a/test/human_test.go
+++ b/test/human_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/starius/api2"
-	"github.com/starius/api2/errors"
+	"github.com/CyberhavenInc/api2"
+	"github.com/CyberhavenInc/api2/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/test/max_body_test.go
+++ b/test/max_body_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 )
 
 func TestMaxBody(t *testing.T) {

--- a/test/protobuf_test.go
+++ b/test/protobuf_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/test/streams_test.go
+++ b/test/streams_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/starius/api2"
+	"github.com/CyberhavenInc/api2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/test/url_params_test.go
+++ b/test/url_params_test.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/starius/api2"
-	"github.com/starius/api2/errors"
+	"github.com/CyberhavenInc/api2"
+	"github.com/CyberhavenInc/api2/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/ts_client.go
+++ b/ts_client.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"text/template"
 
-	"github.com/starius/api2/typegen"
+	"github.com/CyberhavenInc/api2/typegen"
 )
 
 type funcer interface {

--- a/typegen/tests/analyze_test.go
+++ b/typegen/tests/analyze_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	gots "github.com/starius/api2/typegen"
-	"github.com/starius/api2/typegen/tests/types"
+	gots "github.com/CyberhavenInc/api2/typegen"
+	"github.com/CyberhavenInc/api2/typegen/tests/types"
 )
 
 func TestV2(t *testing.T) {

--- a/yaml_client.go
+++ b/yaml_client.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"text/template"
 
-	"github.com/starius/api2/typegen"
+	"github.com/CyberhavenInc/api2/typegen"
 )
 
 const yamlRoutes = `{{- range $key, $services := .}}


### PR DESCRIPTION
Fix module name for importing in other projects, otherwise it gives error on import and `go mod tidy`:
```
module declares its path as: github.com/starius/api2
	        but was required as: github.com/CyberhavenInc/api2
```