### PR TITLE
DDR-15753 support parsing URL params with multiple components separated by "/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,54 @@ HTTP methods must be different so that they can be distinguished.
 If `Transport` is not set, `DefaultTransport` is used which is defined as
 `&api2.JsonTransport{}`.
 
+## Wildcard URL Parameters
+
+API2 supports wildcard URL parameters that can capture multiple path segments, including forward slashes. This is useful for building APIs that need to handle dynamic paths or file-like structures.
+
+### Wildcard Syntax
+
+Use `:param*` in your route path to define a wildcard parameter that captures zero or more path segments:
+
+```go
+{Method: http.MethodPost, Path: "/files/:path*", Handler: api2.Method(&s, "GetFile")}
+{Method: http.MethodPost, Path: "/api/:version/data/:segments*", Handler: api2.Method(&s, "ProcessData")}
+```
+
+### Examples
+
+**Basic wildcard** - captures remaining path segments:
+- Route: `/files/:path*`
+- URL: `/files/documents/reports/2023/summary.pdf`
+- Captured: `path = "documents/reports/2023/summary.pdf"`
+
+**Wildcard in the middle** - captures segments between static parts:
+- Route: `/api/:version/data/:segments*/processed`
+- URL: `/api/v1/data/user/123/settings/processed`
+- Captured: `version = "v1"`, `segments = "user/123/settings"`
+
+**Complex patterns** with multiple wildcards:
+- Route: `/complex/:param_a/static-part/:param_b*/static-part/:param_c/end`
+- URL: `/complex/value1/static-part/deep/nested/path/static-part/value3/end`
+- Captured: `param_a = "value1"`, `param_b = "deep/nested/path"`, `param_c = "value3"`
+
+### Route Specificity and Conflicts
+
+API2 automatically detects and prevents route conflicts. Routes are ordered by specificity:
+
+1. **Static segments** (highest priority)
+2. **Regular parameters** (`:param`)
+3. **Wildcard parameters** (`:param*`, lowest priority)
+
+Routes with higher specificity scores are matched first, preventing less specific wildcard routes from intercepting more specific ones.
+If routes are not sorted properly, app crashes with descriptive error, asking to sort routes properly.
+
+### Demo Endpoints
+
+The [example](./example) directory includes demo endpoints that showcase wildcard functionality:
+
+- **BasicWildcard**: `POST /wildcard/:param_a/static-part/:param_b*` - demonstrates simple wildcard usage
+- **AdvancedWildcard**: `POST /wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part/:param_d*/static_part/:param_e/static_part/:param_f*/static_part` - demonstrates complex patterns with multiple wildcards
+
 **Error handling**. A handler can return any Go error. `JsonTransport`
 by default returns JSON. `Error()` value is put into "error" field of
 that JSON. If the error has `HttpCode() int` method, it is called and

--- a/example/client.go
+++ b/example/client.go
@@ -86,3 +86,21 @@ func (c *Client) Raw(ctx context.Context, req *RawRequest) (res *RawResponse, er
 	}
 	return
 }
+
+func (c *Client) AdvancedWildcard(ctx context.Context, req *AdvancedWildcardRequest) (res *AdvancedWildcardResponse, err error) {
+	res = &AdvancedWildcardResponse{}
+	err = c.api2client.Call(ctx, res, req)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+func (c *Client) BasicWildcard(ctx context.Context, req *BasicWildcardRequest) (res *BasicWildcardResponse, err error) {
+	res = &BasicWildcardResponse{}
+	err = c.api2client.Call(ctx, res, req)
+	if err != nil {
+		return nil, err
+	}
+	return
+}

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -84,4 +84,32 @@ func main() {
 		panic(err)
 	}
 	fmt.Println(string(rawRes.Token))
+
+	advancedRes, err := client.AdvancedWildcard(ctx, &example.AdvancedWildcardRequest{
+		ParamA: "A",
+		ParamB: "B/B",
+		ParamC: "C",
+		ParamD: "D/D/D",
+		ParamE: "E",
+		ParamF: "F/F/F/F",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(advancedRes.Token))
+	if "AdvancedWildcard: A B/B C D/D/D E F/F/F/F" != string(advancedRes.Token) {
+		panic("unexpected advanced wildcard response")
+	}
+
+	basicRes, err := client.BasicWildcard(ctx, &example.BasicWildcardRequest{
+		ParamA: "A",
+		ParamB: "B/B/B",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(basicRes.Token))
+	if "BasicWildcard: A B/B/B" != string(basicRes.Token) {
+		panic("unexpected basic wildcard response: " + string(basicRes.Token))
+	}
 }

--- a/example/echo_service.go
+++ b/example/echo_service.go
@@ -111,3 +111,15 @@ func (s *EchoService) Raw(ctx context.Context, req *RawRequest) (*RawResponse, e
 		Token: req.Token,
 	}, nil
 }
+
+func (s *EchoService) AdvancedWildcard(ctx context.Context, req *AdvancedWildcardRequest) (*AdvancedWildcardResponse, error) {
+	return &AdvancedWildcardResponse{
+		Token: []byte(fmt.Sprintf("AdvancedWildcard: %s %s %s %s %s %s", req.ParamA, req.ParamB, req.ParamC, req.ParamD, req.ParamE, req.ParamF)),
+	}, nil
+}
+
+func (s *EchoService) BasicWildcard(ctx context.Context, req *BasicWildcardRequest) (*BasicWildcardResponse, error) {
+	return &BasicWildcardResponse{
+		Token: []byte(fmt.Sprintf("BasicWildcard: %s %s", req.ParamA, req.ParamB)),
+	}, nil
+}

--- a/example/openapi/openapi.json
+++ b/example/openapi/openapi.json
@@ -1,6 +1,24 @@
 {
  "components": {
   "requestBodies": {
+   "example.AdvancedWildcardRequest": {
+    "content": {
+     "application/json": {
+      "schema": {
+       "$ref": "#/components/schemas/example.AdvancedWildcardRequest"
+      }
+     }
+    }
+   },
+   "example.BasicWildcardRequest": {
+    "content": {
+     "application/json": {
+      "schema": {
+       "$ref": "#/components/schemas/example.BasicWildcardRequest"
+      }
+     }
+    }
+   },
    "example.EchoRequest": {
     "content": {
      "application/json": {
@@ -57,6 +75,18 @@
    }
   },
   "schemas": {
+   "example.AdvancedWildcardRequest": {
+    "type": "object"
+   },
+   "example.AdvancedWildcardResponse": {
+    "type": "object"
+   },
+   "example.BasicWildcardRequest": {
+    "type": "object"
+   },
+   "example.BasicWildcardResponse": {
+    "type": "object"
+   },
    "example.Color": {
     "enum": [
      "color_blue",
@@ -208,8 +238,17 @@
  },
  "openapi": "3.0.0",
  "paths": {
-  "/echo/:user": {
+  "/echo/{user}": {
    "post": {
+    "parameters": [
+     {
+      "in": "path",
+      "name": "user",
+      "schema": {
+       "type": "string"
+      }
+     }
+    ],
     "requestBody": {
      "$ref": "#/components/requestBodies/example.EchoRequest"
     },
@@ -235,6 +274,15 @@
   },
   "/hello": {
    "post": {
+    "parameters": [
+     {
+      "in": "query",
+      "name": "key",
+      "schema": {
+       "type": "string"
+      }
+     }
+    ],
     "requestBody": {
      "$ref": "#/components/requestBodies/example.HelloRequest"
     },
@@ -285,9 +333,15 @@
   },
   "/redirect": {
    "get": {
-    "requestBody": {
-     "$ref": "#/components/requestBodies/example.RedirectRequest"
-    },
+    "parameters": [
+     {
+      "in": "query",
+      "name": "id",
+      "schema": {
+       "type": "string"
+      }
+     }
+    ],
     "responses": {
      "200": {
       "content": {
@@ -344,6 +398,116 @@
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/example.StreamResponse"
+        }
+       }
+      },
+      "description": "info"
+     },
+     "default": {
+      "description": ""
+     }
+    },
+    "tags": [
+     "example"
+    ]
+   }
+  },
+  "/wildcard/{param_a}/static-part/{param_b*}": {
+   "post": {
+    "parameters": [
+     {
+      "in": "path",
+      "name": "param_a",
+      "schema": {
+       "type": "string"
+      }
+     },
+     {
+      "in": "path",
+      "name": "param_b",
+      "schema": {
+       "type": "string"
+      }
+     }
+    ],
+    "requestBody": {
+     "$ref": "#/components/requestBodies/example.BasicWildcardRequest"
+    },
+    "responses": {
+     "200": {
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/example.BasicWildcardResponse"
+        }
+       }
+      },
+      "description": "info"
+     },
+     "default": {
+      "description": ""
+     }
+    },
+    "tags": [
+     "example"
+    ]
+   }
+  },
+  "/wildcard/{param_a}/static-part/{param_b*}/static-part/{param_c}/static_part/{param_d*}/static_part/{param_e}/static_part/{param_f*}/static_part": {
+   "post": {
+    "parameters": [
+     {
+      "in": "path",
+      "name": "param_a",
+      "schema": {
+       "type": "string"
+      }
+     },
+     {
+      "in": "path",
+      "name": "param_b",
+      "schema": {
+       "type": "string"
+      }
+     },
+     {
+      "in": "path",
+      "name": "param_c",
+      "schema": {
+       "type": "string"
+      }
+     },
+     {
+      "in": "path",
+      "name": "param_d",
+      "schema": {
+       "type": "string"
+      }
+     },
+     {
+      "in": "path",
+      "name": "param_e",
+      "schema": {
+       "type": "string"
+      }
+     },
+     {
+      "in": "path",
+      "name": "param_f",
+      "schema": {
+       "type": "string"
+      }
+     }
+    ],
+    "requestBody": {
+     "$ref": "#/components/requestBodies/example.AdvancedWildcardRequest"
+    },
+    "responses": {
+     "200": {
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/example.AdvancedWildcardResponse"
         }
        }
       },

--- a/example/rego/routes.yaml
+++ b/example/rego/routes.yaml
@@ -19,3 +19,9 @@ example:
     Raw:
       method: "POST"
       path: "/raw"
+    AdvancedWildcard:
+      method: "POST"
+      path: "/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part/:param_d*/static_part/:param_e/static_part/:param_f*/static_part"
+    BasicWildcard:
+      method: "POST"
+      path: "/wildcard/:param_a/static-part/:param_b*"

--- a/example/routes.go
+++ b/example/routes.go
@@ -14,5 +14,7 @@ func GetRoutes(s IEchoService) []api2.Route {
 		{Method: http.MethodPut, Path: "/stream", Handler: api2.Method(&s, "Stream")},
 		{Method: http.MethodGet, Path: "/redirect", Handler: api2.Method(&s, "Redirect")},
 		{Method: http.MethodPost, Path: "/raw", Handler: api2.Method(&s, "Raw")},
+		{Method: http.MethodPost, Path: "/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part/:param_d*/static_part/:param_e/static_part/:param_f*/static_part", Handler: api2.Method(&s, "AdvancedWildcard")},
+		{Method: http.MethodPost, Path: "/wildcard/:param_a/static-part/:param_b*", Handler: api2.Method(&s, "BasicWildcard")},
 	}
 }

--- a/example/ts-types/gen.ts
+++ b/example/ts-types/gen.ts
@@ -31,6 +31,14 @@ example: {
 				"POST", "/raw",
 				{},
 				{}),
+			AdvancedWildcard: route<example.AdvancedWildcardRequest, example.AdvancedWildcardResponse>(
+				"POST", "/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part/:param_d*/static_part/:param_e/static_part/:param_f*/static_part",
+				{},
+				{}),
+			BasicWildcard: route<example.BasicWildcardRequest, example.BasicWildcardResponse>(
+				"POST", "/wildcard/:param_a/static-part/:param_b*",
+				{},
+				{}),
 	},
 },
 }
@@ -126,6 +134,22 @@ export type RawRequest = {
 
 
 export type RawResponse = {
+}
+
+
+export type AdvancedWildcardRequest = {
+}
+
+
+export type AdvancedWildcardResponse = {
+}
+
+
+export type BasicWildcardRequest = {
+}
+
+
+export type BasicWildcardResponse = {
 }
 
 

--- a/example/types.go
+++ b/example/types.go
@@ -173,6 +173,28 @@ type RawResponse struct {
 	Token []byte `use_as_body:"true" is_raw:"true"`
 }
 
+type AdvancedWildcardRequest struct {
+	ParamA string `url:"param_a"`
+	ParamB string `url:"param_b"`
+	ParamC string `url:"param_c"`
+	ParamD string `url:"param_d"`
+	ParamE string `url:"param_e"`
+	ParamF string `url:"param_f"`
+}
+
+type AdvancedWildcardResponse struct {
+	Token []byte `use_as_body:"true" is_raw:"true"`
+}
+
+type BasicWildcardRequest struct {
+	ParamA string `url:"param_a"`
+	ParamB string `url:"param_b"`
+}
+
+type BasicWildcardResponse struct {
+	Token []byte `use_as_body:"true" is_raw:"true"`
+}
+
 type IEchoService interface {
 	Hello(ctx context.Context, req *HelloRequest) (*HelloResponse, error)
 	Echo(ctx context.Context, req *EchoRequest) (*EchoResponse, error)
@@ -180,4 +202,6 @@ type IEchoService interface {
 	Stream(ctx context.Context, req *StreamRequest) (*StreamResponse, error)
 	Redirect(ctx context.Context, req *RedirectRequest) (*RedirectResponse, error)
 	Raw(ctx context.Context, req *RawRequest) (*RawResponse, error)
+	AdvancedWildcard(ctx context.Context, req *AdvancedWildcardRequest) (*AdvancedWildcardResponse, error)
+	BasicWildcard(ctx context.Context, req *BasicWildcardRequest) (*BasicWildcardResponse, error)
 }

--- a/server.go
+++ b/server.go
@@ -34,6 +34,23 @@ func BindRoutes(mux Router, routes []Route, opts ...Option) {
 	errorf := config.errorf
 	human := config.human
 
+	routePaths := make([]string, len(routes))
+	for i, route := range routes {
+		routePaths[i] = fmt.Sprintf("%s: %s", route.Method, route.Path)
+	}
+
+	// Detect route conflicts
+	conflicts := detectRouteConflicts(routePaths)
+	if len(conflicts) > 0 {
+		for _, conflict := range conflicts {
+			conflictMsg := fmt.Sprintf("Route conflict detected:\n  Route %d: %s (specificity score: %d)\n  Route %d: %s (specificity score: %d)\n  Issue: Less specific route appears before more specific route",
+				conflict.route1Index, conflict.route1Path, conflict.route1Score,
+				conflict.route2Index, conflict.route2Path, conflict.route2Score)
+
+			panic(fmt.Sprintf("ROUTE VALIDATION FAILED: %s\n\nSuggestion: reorder routes manually with more specific routes first.", conflictMsg))
+		}
+	}
+
 	path2routes := make(map[string][]Route)
 	for _, route := range routes {
 		path := cutUrlParams(route.Path)

--- a/static_client.go
+++ b/static_client.go
@@ -207,6 +207,24 @@ func GenerateClientCode(getRoutess ...interface{}) (code, clientFile string, err
 		}
 	}
 
+	// Validate route ordering to prevent conflicts
+	routePaths := make([]string, len(routes))
+	for i, route := range routes {
+		routePaths[i] = fmt.Sprintf("%s: %s", route.Method, route.Path)
+	}
+
+	// Detect route conflicts using existing validation logic
+	conflicts := detectRouteConflicts(routePaths)
+	if len(conflicts) > 0 {
+		for _, conflict := range conflicts {
+			conflictMsg := fmt.Sprintf("Route conflict detected:\n  Route %d: %s (specificity score: %d)\n  Route %d: %s (specificity score: %d)\n  Issue: Less specific route appears before more specific route",
+				conflict.route1Index, conflict.route1Path, conflict.route1Score,
+				conflict.route2Index, conflict.route2Path, conflict.route2Score)
+
+			return "", "", fmt.Errorf("ROUTE VALIDATION FAILED: %s\n\nSuggestion: reorder routes manually with more specific routes first.", conflictMsg)
+		}
+	}
+
 	code, err = runTemplate(routes, pkg, api2pkg, getRoutesNames, serviceInterfaces)
 	if err != nil {
 		return "", "", err

--- a/ts_client.go
+++ b/ts_client.go
@@ -2,6 +2,7 @@ package api2
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -138,6 +139,25 @@ func GenerateTSClient(options *TypesGenConfig) {
 		routes := routesValues[0].Interface().([]Route)
 		allRoutes = append(allRoutes, routes...)
 	}
+
+	// Validate route ordering to prevent conflicts
+	routePaths := make([]string, len(allRoutes))
+	for i, route := range allRoutes {
+		routePaths[i] = fmt.Sprintf("%s: %s", route.Method, route.Path)
+	}
+
+	// Detect route conflicts using existing validation logic
+	conflicts := detectRouteConflicts(routePaths)
+	if len(conflicts) > 0 {
+		for _, conflict := range conflicts {
+			conflictMsg := fmt.Sprintf("Route conflict detected:\n  Route %d: %s (specificity score: %d)\n  Route %d: %s (specificity score: %d)\n  Issue: Less specific route appears before more specific route",
+				conflict.route1Index, conflict.route1Path, conflict.route1Score,
+				conflict.route2Index, conflict.route2Path, conflict.route2Score)
+
+			panicIf(fmt.Errorf("ROUTE VALIDATION FAILED: %s\n\nSuggestion: reorder routes manually with more specific routes first.", conflictMsg))
+		}
+	}
+
 	genRoutes(typesFile, allRoutes, parser, options)
 	if _, err := os.Stat(filepath.Join(options.OutDir, "utils.ts")); os.IsNotExist(err) {
 		utilsFile, err := os.OpenFile(filepath.Join(options.OutDir, "utils.ts"), os.O_WRONLY|os.O_CREATE, 0755)

--- a/url_params.go
+++ b/url_params.go
@@ -2,6 +2,7 @@ package api2
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -458,15 +459,14 @@ func sortRoutesBySpecificity(routePaths []string) []string {
 	}
 
 	// Sort by specificity score (highest first), then by original index for stability
-	for i := 0; i < len(routes); i++ {
-		for j := i + 1; j < len(routes); j++ {
-			// Higher score should come first
-			if routes[i].specificity.score < routes[j].specificity.score ||
-				(routes[i].specificity.score == routes[j].specificity.score && routes[i].originalIndex > routes[j].originalIndex) {
-				routes[i], routes[j] = routes[j], routes[i]
-			}
+	slices.SortFunc(routes, func(a, b routeWithSpec) int {
+		// Higher score should come first
+		if a.specificity.score != b.specificity.score {
+			return b.specificity.score - a.specificity.score // descending order
 		}
-	}
+		// If scores are equal, maintain original order (ascending)
+		return a.originalIndex - b.originalIndex
+	})
 
 	// Extract sorted paths
 	sortedPaths := make([]string, len(routes))

--- a/url_params.go
+++ b/url_params.go
@@ -7,10 +7,34 @@ import (
 
 type paramMapType struct{}
 
+type wildcardInfo struct {
+	position int    // position in the path parts array
+	name     string // parameter name without prefix
+}
+
+type routeSpecificity struct {
+	staticSegments   int  // number of static path segments
+	regularParams    int  // number of regular parameters (:param)
+	wildcardParams   int  // number of wildcard parameters (:param*)
+	endsWithWildcard bool // true if route ends with a wildcard parameter
+	score            int  // calculated specificity score
+}
+
+type routeConflict struct {
+	route1Index int
+	route2Index int
+	route1Path  string
+	route2Path  string
+	route1Score int
+	route2Score int
+	message     string
+}
+
 type classifier struct {
 	maskPartsArray [][]string
 	paramsArray    [][]bool
 	paramsNum      []int
+	wildcardArray  [][]wildcardInfo // wildcard information for each route
 }
 
 func splitUrl(url string) []string {
@@ -28,56 +52,196 @@ func newPathClassifier(masks []string) *classifier {
 	maskPartsArray := make([][]string, 0, len(masks))
 	paramsArray := make([][]bool, 0, len(masks))
 	paramsNum := make([]int, 0, len(masks))
+	wildcardArray := make([][]wildcardInfo, 0, len(masks))
+
 	for _, mask := range masks {
 		parts := splitUrl(mask)
 		params := make([]bool, len(parts))
+		wildcards := make([]wildcardInfo, 0)
 		count := 0
+
 		for i, part := range parts {
 			if strings.HasPrefix(part, ":") {
-				parts[i] = strings.TrimPrefix(part, ":")
+				paramName := strings.TrimPrefix(part, ":")
+
+				// Check for wildcard suffix
+				if strings.HasSuffix(paramName, "*") {
+					// Wildcard parameter (zero or more segments)
+					paramName = strings.TrimSuffix(paramName, "*")
+					wildcards = append(wildcards, wildcardInfo{
+						position: i,
+						name:     paramName,
+					})
+				}
+
+				parts[i] = paramName
 				params[i] = true
 				count++
 			}
 		}
+
 		maskPartsArray = append(maskPartsArray, parts)
 		paramsArray = append(paramsArray, params)
 		paramsNum = append(paramsNum, count)
+		wildcardArray = append(wildcardArray, wildcards)
 	}
+
 	return &classifier{
 		maskPartsArray: maskPartsArray,
 		paramsArray:    paramsArray,
 		paramsNum:      paramsNum,
+		wildcardArray:  wildcardArray,
 	}
 }
 
 func match(pathParts, maskParts []string, params []bool, count int) (bool, map[string]string) {
-	if len(pathParts) != len(maskParts) {
-		return false, nil
-	}
-	// Check if all static parts match.
-	for i := 0; i < len(pathParts); i++ {
-		if !params[i] && pathParts[i] != maskParts[i] {
+	return matchWithWildcards(pathParts, maskParts, params, count, nil)
+}
+
+func matchWithWildcards(pathParts, maskParts []string, params []bool, count int, wildcards []wildcardInfo) (bool, map[string]string) {
+	// If no wildcards, use the original simple matching logic
+	if len(wildcards) == 0 {
+		if len(pathParts) != len(maskParts) {
 			return false, nil
 		}
-	}
-	// Fill values of the parameters.
-	param2value := make(map[string]string, count)
-	for i := 0; i < len(pathParts); i++ {
-		if !params[i] {
-			continue
+		// Check if all static parts match.
+		for i := 0; i < len(pathParts); i++ {
+			if !params[i] && pathParts[i] != maskParts[i] {
+				return false, nil
+			}
 		}
-		key := maskParts[i]
-		value := pathParts[i]
-		param2value[key] = value
+		// Fill values of the parameters.
+		param2value := make(map[string]string, count)
+		for i := 0; i < len(pathParts); i++ {
+			if !params[i] {
+				continue
+			}
+			key := maskParts[i]
+			value := pathParts[i]
+			param2value[key] = value
+		}
+		return true, param2value
 	}
+
+	// Complex matching with wildcards
+	return matchWildcardPattern(pathParts, maskParts, params, wildcards)
+}
+
+func matchWildcardPattern(pathParts, maskParts []string, params []bool, wildcards []wildcardInfo) (bool, map[string]string) {
+	param2value := make(map[string]string)
+
+	// For each wildcard, we need to determine what segments it should capture
+	pathIndex := 0
+	maskIndex := 0
+
+	for maskIndex < len(maskParts) {
+		// Check if current mask position is a wildcard
+		isWildcard := false
+		var wildcardInfo wildcardInfo
+		for _, wc := range wildcards {
+			if wc.position == maskIndex {
+				isWildcard = true
+				wildcardInfo = wc
+				break
+			}
+		}
+
+		if isWildcard {
+			// Find the next static segment after this wildcard to determine boundaries
+			nextStaticIndex := findNextStaticSegment(maskParts, maskIndex+1, params)
+
+			if nextStaticIndex == -1 {
+				// Wildcard is at the end - capture remaining path segments
+				if pathIndex < len(pathParts) {
+					remainingSegments := pathParts[pathIndex:]
+					param2value[wildcardInfo.name] = strings.Join(remainingSegments, "/")
+					pathIndex = len(pathParts) // consumed all remaining segments
+				} else {
+					// Wildcard at the end can match zero segments
+					param2value[wildcardInfo.name] = ""
+				}
+				// Since wildcard is at the end, we can finish processing
+				maskIndex = len(maskParts)
+				break
+			} else {
+				// Find where the next static segment pattern matches in the path
+				matchPos := findStaticPattern(pathParts, pathIndex, maskParts, nextStaticIndex, params)
+				if matchPos == -1 {
+					return false, nil
+				}
+
+				// Calculate how many segments the wildcard should capture
+				capturedSegments := pathParts[pathIndex:matchPos]
+
+				param2value[wildcardInfo.name] = strings.Join(capturedSegments, "/")
+				pathIndex = matchPos
+			}
+		} else if params[maskIndex] {
+			// Regular parameter - must match exactly one segment
+			if pathIndex >= len(pathParts) {
+				return false, nil
+			}
+			param2value[maskParts[maskIndex]] = pathParts[pathIndex]
+			pathIndex++
+		} else {
+			// Static segment - must match exactly
+			if pathIndex >= len(pathParts) || pathParts[pathIndex] != maskParts[maskIndex] {
+				return false, nil
+			}
+			pathIndex++
+		}
+
+		maskIndex++
+	}
+
+	// Ensure we've consumed all path segments
+	if pathIndex != len(pathParts) {
+		return false, nil
+	}
+
 	return true, param2value
+}
+
+func findNextStaticSegment(maskParts []string, startIndex int, params []bool) int {
+	for i := startIndex; i < len(maskParts); i++ {
+		if !params[i] {
+			return i
+		}
+	}
+	return -1
+}
+
+func findStaticPattern(pathParts []string, startIndex int, maskParts []string, maskStartIndex int, params []bool) int {
+	// Find the end of the static pattern we're looking for
+	patternEnd := maskStartIndex
+	for patternEnd < len(maskParts) && !params[patternEnd] {
+		patternEnd++
+	}
+
+	patternLength := patternEnd - maskStartIndex
+
+	// Search for this pattern in the remaining path
+	for i := startIndex; i <= len(pathParts)-patternLength; i++ {
+		match := true
+		for j := 0; j < patternLength; j++ {
+			if pathParts[i+j] != maskParts[maskStartIndex+j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+
+	return -1
 }
 
 // Classify returns index of matching mask (-1 if not found) and parameters map.
 func (c *classifier) Classify(path string) (index int, param2value map[string]string) {
 	pathParts := splitUrl(path)
 	for i, maskParts := range c.maskPartsArray {
-		ok, param2value := match(pathParts, maskParts, c.paramsArray[i], c.paramsNum[i])
+		ok, param2value := matchWithWildcards(pathParts, maskParts, c.paramsArray[i], c.paramsNum[i], c.wildcardArray[i])
 		if ok {
 			return i, param2value
 		}
@@ -90,7 +254,12 @@ func findUrlKeys(mask string) []string {
 	result := make([]string, 0, len(parts))
 	for _, part := range parts {
 		if strings.HasPrefix(part, ":") {
-			result = append(result, strings.TrimPrefix(part, ":"))
+			paramName := strings.TrimPrefix(part, ":")
+			// Strip wildcard suffixes for parameter name consistency
+			if strings.HasSuffix(paramName, "*") {
+				paramName = strings.TrimSuffix(paramName, "*")
+			}
+			result = append(result, paramName)
 		}
 	}
 	return result
@@ -114,16 +283,196 @@ func buildUrl(mask string, param2value map[string]string) (string, error) {
 		if !strings.HasPrefix(part, ":") {
 			continue
 		}
-		part = strings.TrimPrefix(part, ":")
-		value, has := param2value[part]
+		paramName := strings.TrimPrefix(part, ":")
+		// Strip wildcard suffixes for parameter lookup
+		if strings.HasSuffix(paramName, "*") {
+			paramName = strings.TrimSuffix(paramName, "*")
+		}
+		value, has := param2value[paramName]
 		if !has {
-			return "", fmt.Errorf("unknown parameter: %s", part)
+			return "", fmt.Errorf("unknown parameter: %s", paramName)
 		}
 		urlParts[i] = value
-		replaced[part] = struct{}{}
+		replaced[paramName] = struct{}{}
 	}
 	if len(replaced) != len(param2value) {
 		return "", fmt.Errorf("not all parameters were built into URL: want %d, got %d", len(param2value), len(replaced))
 	}
 	return strings.Join(urlParts, "/"), nil
+}
+
+// calculateRouteSpecificity analyzes a route pattern and returns its specificity metrics
+func calculateRouteSpecificity(routePath string) routeSpecificity {
+	parts := splitUrl(routePath)
+
+	var staticSegments, regularParams, wildcardParams int
+	var endsWithWildcard bool
+
+	for i, part := range parts {
+		if strings.HasPrefix(part, ":") {
+			paramName := strings.TrimPrefix(part, ":")
+			if strings.HasSuffix(paramName, "*") {
+				wildcardParams++
+				if i == len(parts)-1 {
+					endsWithWildcard = true
+				}
+			} else {
+				regularParams++
+			}
+		} else {
+			staticSegments++
+		}
+	}
+
+	// Specificity scoring: higher score = more specific route
+	// Formula: (static_segments × 100) + (regular_params × 10) - (wildcard_params × 50) - (ends_with_wildcard × 25)
+	score := (staticSegments * 100) + (regularParams * 10) - (wildcardParams * 50)
+	if endsWithWildcard {
+		score -= 25
+	}
+
+	return routeSpecificity{
+		staticSegments:   staticSegments,
+		regularParams:    regularParams,
+		wildcardParams:   wildcardParams,
+		endsWithWildcard: endsWithWildcard,
+		score:            score,
+	}
+}
+
+// detectRouteConflicts analyzes a list of route patterns for potential conflicts
+func detectRouteConflicts(routePaths []string) []routeConflict {
+	conflicts := make([]routeConflict, 0)
+
+	// Calculate specificity for all routes
+	specificities := make([]routeSpecificity, len(routePaths))
+	for i, path := range routePaths {
+		specificities[i] = calculateRouteSpecificity(strings.Split(path, ": ")[1]) // Ignore HTTP method prefix
+	}
+
+	// Check each pair of routes for conflicts
+	for i := 0; i < len(routePaths); i++ {
+		for j := i + 1; j < len(routePaths); j++ {
+			if routesCanConflict(routePaths[i], routePaths[j]) {
+				// Determine which route has higher specificity
+				route1Spec := specificities[i]
+				route2Spec := specificities[j]
+
+				// If a less specific route appears before a more specific one, it's a conflict
+				if route1Spec.score < route2Spec.score {
+					conflicts = append(conflicts, routeConflict{
+						route1Index: i,
+						route2Index: j,
+						route1Path:  routePaths[i],
+						route2Path:  routePaths[j],
+						route1Score: route1Spec.score,
+						route2Score: route2Spec.score,
+						message:     fmt.Sprintf("Route %d (score: %d) is less specific than route %d (score: %d) but appears first", i, route1Spec.score, j, route2Spec.score),
+					})
+				}
+			}
+		}
+	}
+
+	return conflicts
+}
+
+// routesCanConflict checks if two route patterns could potentially match the same URL
+func routesCanConflict(route1, route2 string) bool {
+	method1 := strings.SplitN(route1, ": ", 2)[0]
+	method2 := strings.SplitN(route2, ": ", 2)[0]
+	if method1 != method2 {
+		return false // Different HTTP methods can't conflict
+	}
+	parts1 := splitUrl(route1)
+	parts2 := splitUrl(route2)
+
+	// Routes can only conflict if they start with the same pattern
+	minLen := len(parts1)
+	if len(parts2) < minLen {
+		minLen = len(parts2)
+	}
+
+	for i := 0; i < minLen; i++ {
+		part1 := parts1[i]
+		part2 := parts2[i]
+
+		// If both are static and different, they can't conflict
+		if !strings.HasPrefix(part1, ":") && !strings.HasPrefix(part2, ":") {
+			if part1 != part2 {
+				return false
+			}
+			continue
+		}
+
+		// If one is a wildcard, they can potentially conflict
+		if (strings.HasPrefix(part1, ":") && strings.HasSuffix(part1, "*")) ||
+			(strings.HasPrefix(part2, ":") && strings.HasSuffix(part2, "*")) {
+			return true
+		}
+
+		// Both are parameters (regular or wildcard), they can potentially conflict
+		if strings.HasPrefix(part1, ":") && strings.HasPrefix(part2, ":") {
+			continue
+		}
+	}
+
+	// If we've reached here and routes have the same length, they can conflict
+	if len(parts1) == len(parts2) {
+		return true
+	}
+
+	// If one route is longer, they could conflict if the shorter has wildcards
+	shorterParts := parts1
+	if len(parts2) < len(parts1) {
+		shorterParts = parts2
+	}
+
+	// Check if the shorter route ends with a wildcard
+	if len(shorterParts) > 0 {
+		lastPart := shorterParts[len(shorterParts)-1]
+		if strings.HasPrefix(lastPart, ":") && strings.HasSuffix(lastPart, "*") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// sortRoutesBySpecificity sorts route patterns by their specificity scores (highest first)
+func sortRoutesBySpecificity(routePaths []string) []string {
+	// Create pairs of (route, specificity) for sorting
+	type routeWithSpec struct {
+		path          string
+		specificity   routeSpecificity
+		originalIndex int
+	}
+
+	routes := make([]routeWithSpec, len(routePaths))
+	for i, path := range routePaths {
+		routes[i] = routeWithSpec{
+			path:          path,
+			specificity:   calculateRouteSpecificity(path),
+			originalIndex: i,
+		}
+	}
+
+	// Sort by specificity score (highest first), then by original index for stability
+	for i := 0; i < len(routes); i++ {
+		for j := i + 1; j < len(routes); j++ {
+			// Higher score should come first
+			if routes[i].specificity.score < routes[j].specificity.score ||
+				(routes[i].specificity.score == routes[j].specificity.score && routes[i].originalIndex > routes[j].originalIndex) {
+				routes[i], routes[j] = routes[j], routes[i]
+			}
+		}
+	}
+
+	// Extract sorted paths
+	sortedPaths := make([]string, len(routes))
+	for i, route := range routes {
+		sortedPaths[i] = route.path
+	}
+
+	return sortedPaths
 }

--- a/url_params.go
+++ b/url_params.go
@@ -99,29 +99,33 @@ func match(pathParts, maskParts []string, params []bool, count int) (bool, map[s
 	return matchWithWildcards(pathParts, maskParts, params, count, nil)
 }
 
+func matchSimplePattern(pathParts, maskParts []string, params []bool, count int) (bool, map[string]string) {
+	if len(pathParts) != len(maskParts) {
+		return false, nil
+	}
+	// Check if all static parts match.
+	for i := 0; i < len(pathParts); i++ {
+		if !params[i] && pathParts[i] != maskParts[i] {
+			return false, nil
+		}
+	}
+	// Fill values of the parameters.
+	param2value := make(map[string]string, count)
+	for i := 0; i < len(pathParts); i++ {
+		if !params[i] {
+			continue
+		}
+		key := maskParts[i]
+		value := pathParts[i]
+		param2value[key] = value
+	}
+	return true, param2value
+}
+
 func matchWithWildcards(pathParts, maskParts []string, params []bool, count int, wildcards []wildcardInfo) (bool, map[string]string) {
 	// If no wildcards, use the original simple matching logic
 	if len(wildcards) == 0 {
-		if len(pathParts) != len(maskParts) {
-			return false, nil
-		}
-		// Check if all static parts match.
-		for i := 0; i < len(pathParts); i++ {
-			if !params[i] && pathParts[i] != maskParts[i] {
-				return false, nil
-			}
-		}
-		// Fill values of the parameters.
-		param2value := make(map[string]string, count)
-		for i := 0; i < len(pathParts); i++ {
-			if !params[i] {
-				continue
-			}
-			key := maskParts[i]
-			value := pathParts[i]
-			param2value[key] = value
-		}
-		return true, param2value
+		return matchSimplePattern(pathParts, maskParts, params, count)
 	}
 
 	// Complex matching with wildcards

--- a/url_params_test.go
+++ b/url_params_test.go
@@ -293,7 +293,7 @@ func TestRouteSpecificity(t *testing.T) {
 		{
 			name:             "complex route with multiple parameters",
 			routePath:        "/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part",
-			expectedStatic:   4, // "complex", "static-part", "static-part", "static_part"
+			expectedStatic:   4, // "wildcard", "static-part", "static-part", "static_part"
 			expectedRegular:  2, // param_a, param_c
 			expectedWildcard: 1, // param_b*
 			expectedEndsWith: false,
@@ -302,7 +302,7 @@ func TestRouteSpecificity(t *testing.T) {
 		{
 			name:             "very complex route",
 			routePath:        "/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part/:param_d*/static_part/:param_e/static_part/:param_f*/static_part",
-			expectedStatic:   7, // "complex", "static-part", "static-part", "static_part", "static_part", "static_part", "static_part"
+			expectedStatic:   7, // "wildcard", "static-part", "static-part", "static_part", "static_part", "static_part", "static_part"
 			expectedRegular:  3, // param_a, param_c, param_e
 			expectedWildcard: 3, // param_b*, param_d*, param_f*
 			expectedEndsWith: false,
@@ -311,7 +311,7 @@ func TestRouteSpecificity(t *testing.T) {
 		{
 			name:             "simple route with wildcard",
 			routePath:        "/wildcard/:param_a/static-part/:param_b*",
-			expectedStatic:   2, // "complex", "static-part"
+			expectedStatic:   2, // "wildcard", "static-part"
 			expectedRegular:  1, // param_a
 			expectedWildcard: 1, // param_b*
 			expectedEndsWith: true,

--- a/url_params_test.go
+++ b/url_params_test.go
@@ -142,6 +142,352 @@ func TestClassifier(t *testing.T) {
 	}
 }
 
+func TestClassifierWithWildcards(t *testing.T) {
+	cl := newPathClassifier([]string{
+		"/data/:path*",
+		"/files/:name/content",
+		"/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part",
+		"/api/:version/items/:id*",
+		"/greedy/:first*/middle/:second*/end",
+	})
+
+	cases := []struct {
+		name            string
+		url             string
+		wantIndex       int
+		wantParam2value map[string]string
+	}{
+		{
+			name:      "simple wildcard with multiple segments",
+			url:       "/data/a/b/c/d",
+			wantIndex: 0,
+			wantParam2value: map[string]string{
+				"path": "a/b/c/d",
+			},
+		},
+		{
+			name:      "wildcard with single segment",
+			url:       "/data/single",
+			wantIndex: 0,
+			wantParam2value: map[string]string{
+				"path": "single",
+			},
+		},
+		{
+			name:      "wildcard with no segments (greedy)",
+			url:       "/data",
+			wantIndex: 0,
+			wantParam2value: map[string]string{
+				"path": "",
+			},
+		},
+		{
+			name:      "complex pattern with wildcard in middle",
+			url:       "/wildcard/a/static-part/b/b1/b2/b3/b4/static-part/c/static_part",
+			wantIndex: 2,
+			wantParam2value: map[string]string{
+				"param_a": "a",
+				"param_b": "b/b1/b2/b3/b4",
+				"param_c": "c",
+			},
+		},
+		{
+			name:      "complex pattern with minimal wildcard content",
+			url:       "/wildcard/x/static-part/y/static-part/z/static_part",
+			wantIndex: 2,
+			wantParam2value: map[string]string{
+				"param_a": "x",
+				"param_b": "y",
+				"param_c": "z",
+			},
+		},
+		{
+			name:      "api with wildcard at end",
+			url:       "/api/v1/items/user/123/settings",
+			wantIndex: 3,
+			wantParam2value: map[string]string{
+				"version": "v1",
+				"id":      "user/123/settings",
+			},
+		},
+		{
+			name:      "api with empty wildcard at end",
+			url:       "/api/v2/items",
+			wantIndex: 3,
+			wantParam2value: map[string]string{
+				"version": "v2",
+				"id":      "",
+			},
+		},
+		{
+			name:      "multiple wildcards",
+			url:       "/greedy/first/part/middle/second/part/end",
+			wantIndex: 4,
+			wantParam2value: map[string]string{
+				"first":  "first/part",
+				"second": "second/part",
+			},
+		},
+		{
+			name:      "non-matching case - should prefer static route",
+			url:       "/files/document.txt/content",
+			wantIndex: 1,
+			wantParam2value: map[string]string{
+				"name": "document.txt",
+			},
+		},
+		{
+			name:      "non-matching - insufficient static parts",
+			url:       "/wildcard/a/static-part/b/b1/wrong-static/c/static_part",
+			wantIndex: -1,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gotIndex, gotParam2value := cl.Classify(tc.url)
+			require.Equal(t, tc.wantIndex, gotIndex, "Expected index %d, got %d for URL %s", tc.wantIndex, gotIndex, tc.url)
+			require.Equal(t, tc.wantParam2value, gotParam2value, "Parameter mismatch for URL %s", tc.url)
+		})
+	}
+}
+
+func TestRouteSpecificity(t *testing.T) {
+	cases := []struct {
+		name             string
+		routePath        string
+		expectedStatic   int
+		expectedRegular  int
+		expectedWildcard int
+		expectedEndsWith bool
+		expectedScore    int
+	}{
+		{
+			name:             "simple static route",
+			routePath:        "/users",
+			expectedStatic:   1,
+			expectedRegular:  0,
+			expectedWildcard: 0,
+			expectedEndsWith: false,
+			expectedScore:    100, // 1*100 + 0*10 - 0*50 - 0*25
+		},
+		{
+			name:             "route with regular parameter",
+			routePath:        "/users/:id",
+			expectedStatic:   1,
+			expectedRegular:  1,
+			expectedWildcard: 0,
+			expectedEndsWith: false,
+			expectedScore:    110, // 1*100 + 1*10 - 0*50 - 0*25
+		},
+		{
+			name:             "route with wildcard at end",
+			routePath:        "/data/:path*",
+			expectedStatic:   1,
+			expectedRegular:  0,
+			expectedWildcard: 1,
+			expectedEndsWith: true,
+			expectedScore:    25, // 1*100 + 0*10 - 1*50 - 1*25
+		},
+		{
+			name:             "complex route with multiple parameters",
+			routePath:        "/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part",
+			expectedStatic:   4, // "complex", "static-part", "static-part", "static_part"
+			expectedRegular:  2, // param_a, param_c
+			expectedWildcard: 1, // param_b*
+			expectedEndsWith: false,
+			expectedScore:    370, // 4*100 + 2*10 - 1*50 - 0*25
+		},
+		{
+			name:             "very complex route",
+			routePath:        "/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part/:param_d*/static_part/:param_e/static_part/:param_f*/static_part",
+			expectedStatic:   7, // "complex", "static-part", "static-part", "static_part", "static_part", "static_part", "static_part"
+			expectedRegular:  3, // param_a, param_c, param_e
+			expectedWildcard: 3, // param_b*, param_d*, param_f*
+			expectedEndsWith: false,
+			expectedScore:    580, // 7*100 + 3*10 - 3*50 - 0*25 = 700 + 30 - 150 = 580
+		},
+		{
+			name:             "simple route with wildcard",
+			routePath:        "/wildcard/:param_a/static-part/:param_b*",
+			expectedStatic:   2, // "complex", "static-part"
+			expectedRegular:  1, // param_a
+			expectedWildcard: 1, // param_b*
+			expectedEndsWith: true,
+			expectedScore:    135, // 2*100 + 1*10 - 1*50 - 1*25
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			spec := calculateRouteSpecificity(tc.routePath)
+			require.Equal(t, tc.expectedStatic, spec.staticSegments, "Static segments mismatch")
+			require.Equal(t, tc.expectedRegular, spec.regularParams, "Regular parameters mismatch")
+			require.Equal(t, tc.expectedWildcard, spec.wildcardParams, "Wildcard parameters mismatch")
+			require.Equal(t, tc.expectedEndsWith, spec.endsWithWildcard, "Ends with wildcard mismatch")
+			require.Equal(t, tc.expectedScore, spec.score, "Specificity score mismatch")
+		})
+	}
+}
+
+func TestRouteConflictDetection(t *testing.T) {
+	cases := []struct {
+		name              string
+		routes            []string
+		expectedConflicts int
+	}{
+		{
+			name:              "no conflicts",
+			routes:            []string{"GET: /users", "GET: /posts", "GET: /comments"},
+			expectedConflicts: 0,
+		},
+		{
+			name:              "simple conflict - wildcard before specific",
+			routes:            []string{"GET: /data/:path*", "GET: /data/specific"},
+			expectedConflicts: 1,
+		},
+		{
+			name: "wildcard conflict - BasicWildcard vs AdvancedWildcard",
+			routes: []string{
+				"GET: /wildcard/:param_a/static-part/:param_b*",
+				"GET: /wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part/:param_d*/static_part/:param_e/static_part/:param_f*/static_part",
+			},
+			expectedConflicts: 1,
+		},
+		{
+			name: "multiple conflicts",
+			routes: []string{
+				"GET: /api/:version*",
+				"GET: /api/:version/users/:id*",
+				"GET: /api/:version/users/:id/posts",
+			},
+			expectedConflicts: 3, // route 0 conflicts with routes 1 and 2, route 1 conflicts with route 2
+		},
+		{
+			name: "no conflict - different starting paths",
+			routes: []string{
+				"GET: /users/:id*",
+				"GET: /posts/:id*",
+			},
+			expectedConflicts: 0,
+		},
+		{
+			name: "multiple conflicts, different methods",
+			routes: []string{
+				"GET: /api/:version*",
+				"GET: /api/:version/users/:id*",
+				"POST: /api/:version/users/:id/posts",
+			},
+			expectedConflicts: 1, // route 0 conflicts with routes 1 but not with 2
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			conflicts := detectRouteConflicts(tc.routes)
+			require.Equal(t, tc.expectedConflicts, len(conflicts), "Number of conflicts mismatch")
+		})
+	}
+}
+
+func TestRouteSorting(t *testing.T) {
+	cases := []struct {
+		name          string
+		routes        []string
+		expectedOrder []string
+	}{
+		{
+			name: "sort by specificity",
+			routes: []string{
+				"/data/:path*",       // score: 25
+				"/data/specific",     // score: 200
+				"/data/:id/comments", // score: 210
+			},
+			expectedOrder: []string{
+				"/data/:id/comments", // score: 210 (highest)
+				"/data/specific",     // score: 200
+				"/data/:path*",       // score: 25 (lowest)
+			},
+		},
+		{
+			name: "AdvancedWildcard/BasicWildcard ordering",
+			routes: []string{
+				"/wildcard/:param_a/static-part/:param_b*", // score: 135
+				"/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part/:param_d*/static_part/:param_e/static_part/:param_f*/static_part", // score: 470
+			},
+			expectedOrder: []string{
+				"/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part/:param_d*/static_part/:param_e/static_part/:param_f*/static_part", // score: 470 (higher)
+				"/wildcard/:param_a/static-part/:param_b*", // score: 135 (lower)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			sorted := sortRoutesBySpecificity(tc.routes)
+			require.Equal(t, tc.expectedOrder, sorted, "Route sorting order mismatch")
+		})
+	}
+}
+
+func TestRoutesCanConflict(t *testing.T) {
+	cases := []struct {
+		name        string
+		route1      string
+		route2      string
+		canConflict bool
+	}{
+		{
+			name:        "identical routes",
+			route1:      "GET: /users/:id",
+			route2:      "GET: /users/:id",
+			canConflict: true,
+		},
+		{
+			name:        "different static paths",
+			route1:      "GET: /users/:id",
+			route2:      "GET: /posts/:id",
+			canConflict: false,
+		},
+		{
+			name:        "wildcard can conflict with specific",
+			route1:      "GET: /data/:path*",
+			route2:      "GET: /data/specific/path",
+			canConflict: true,
+		},
+		{
+			name:        "wildcard vs simple with same prefix",
+			route1:      "GET: /wildcard/:param_a/static-part/:param_b*",
+			route2:      "GET: /wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part",
+			canConflict: true,
+		},
+		{
+			name:        "no conflict - different lengths without wildcards",
+			route1:      "GET: /users/:id",
+			route2:      "GET: /users/:id/posts",
+			canConflict: false,
+		},
+		{
+			name:        "identical routes, different methods",
+			route1:      "GET: /users/:id",
+			route2:      "POST: /users/:id",
+			canConflict: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := routesCanConflict(tc.route1, tc.route2)
+			require.Equal(t, tc.canConflict, result, "Conflict detection result mismatch")
+		})
+	}
+}
+
 func TestSplitUrl(t *testing.T) {
 	cases := []struct {
 		url  string
@@ -201,6 +547,14 @@ func TestFindUrlKeys(t *testing.T) {
 		{
 			mask: "/bar/:foo/zoo/:baz",
 			want: []string{"foo", "baz"},
+		},
+		{
+			mask: "/data/:path*",
+			want: []string{"path"},
+		},
+		{
+			mask: "/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part",
+			want: []string{"param_a", "param_b", "param_c"},
 		},
 	}
 	for _, tc := range cases {
@@ -303,6 +657,24 @@ func TestBuildUrl(t *testing.T) {
 				"user":    "555",
 			},
 			wantError: true,
+		},
+		{
+			name: "wildcard parameter",
+			mask: "/data/:path*",
+			param2value: map[string]string{
+				"path": "a/b/c/d",
+			},
+			want: "/data/a/b/c/d",
+		},
+		{
+			name: "complex wildcard pattern",
+			mask: "/wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part",
+			param2value: map[string]string{
+				"param_a": "a",
+				"param_b": "b/b1/b2/b3/b4",
+				"param_c": "c",
+			},
+			want: "/wildcard/a/static-part/b/b1/b2/b3/b4/static-part/c/static_part",
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
This PR enables wildcard parameters in URL
It was not possible to have route `/abc/:param` matching parameters with many `/` like `/abc/xyz/def` since matching were strictly segment based

___Important___
Given wildcard matching can create very annoying issue because of order based matching, api2 will panic if routes are not sorted in correct order of most specific first, also generation of TypeScript and static Go client would both fail
E.g. routes:
```
POST "users/:id"
POST "users/update_all" 
```
Have a hidden issue - less specific `users/:id` defined fist, and more specific `users/update_all` defined last, so it will never be matched. Wildcard also adds to this issue:
```
POST "users/:id*" 
POST "users/find/:admin_id"  
POST "users/special_users/promote/:id"  
```
In which case first route with wildcard would act greedy and match everything.
To cope with that, api2 would panic in runtime and on generation of TS and Go client
Q: Why not sort routes in runtime instead? 
A: To make it explicit, so that developer can understand matching order
Q: How many existing routes needs to be re-ordered?
A: Only 2 in endpointmanagement API

Here is how "gen-time" failure would look like (for both TS client and Go static client)
```
go run example/gen/main.go                        
2025/09/18 13:24:24 api2 generates static client for /Users/valentynshevchenko/src/CyberhavenInc/api2/example/routes.go ...
2025/09/18 13:24:24 api2 failed to generate static client for /Users/valentynshevchenko/src/CyberhavenInc/api2/example/routes.go: ROUTE VALIDATION FAILED: Route conflict detected:
  Route 6: POST: /wildcard/:param_a/static-part/:param_b* (specificity score: 135)
  Route 7: POST: /wildcard/:param_a/static-part/:param_b*/static-part/:param_c/static_part/:param_d*/static_part/:param_e/static_part/:param_f*/static_part (specificity score: 580)
  Issue: Less specific route appears before more specific route
```
