### PR TITLE
DDR-24917: Remove debug log lines that expose request body content

### DIFF
--- a/json_transport.go
+++ b/json_transport.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -611,21 +610,9 @@ func readQueryHeaderCookie(objPtr interface{}, bodyReadCloser io.ReadCloser, que
 			}
 			if strings.Contains(contentType, "application/json") {
 				if err := protojson.Unmarshal(buf, bodyPtrMessage); err != nil {
-					preview := buf
-					if len(preview) > 256 {
-						preview = preview[:256]
-					}
-					log.Printf("api2: protojson.Unmarshal failed: err=%v content_type=%q body_len=%d body_utf8=%q",
-						err, contentType, len(buf), string(preview))
 					return err
 				}
 			} else if err := proto.Unmarshal(buf, bodyPtrMessage); err != nil {
-				preview := buf
-				if len(preview) > 256 {
-					preview = preview[:256]
-				}
-				log.Printf("api2: proto.Unmarshal failed: err=%v content_type=%q body_len=%d body_hex=%s body_utf8=%q",
-					err, contentType, len(buf), hex.EncodeToString(preview), string(preview))
 				return err
 			}
 		} else if p.Stream {


### PR DESCRIPTION
## Summary
- Remove `log.Printf` calls in `protojson.Unmarshal` and `proto.Unmarshal` error handlers that logged up to 256 bytes of raw request body content
- Remove now-unused `encoding/hex` import
- Errors are still returned to the caller for proper handling

Addresses review feedback from https://github.com/CyberhavenInc/dataflow/pull/27606#discussion_r3011270004

## Test plan
- [ ] Verify unmarshal errors still propagate correctly to callers
- [ ] Confirm no sensitive data appears in logs on content-type mismatches