### PR TITLE
Fix cross-service protobuf decoding when caller ctx carries JSON Content-Type

### DIFF
--- a/json_transport.go
+++ b/json_transport.go
@@ -640,10 +640,7 @@ func readQueryHeaderCookie(allowLegacyBinaryFallback bool, objPtr interface{}, b
 			if err != nil {
 				return "", err
 			}
-			contentType := ""
-			if request != nil {
-				contentType = request.Header.Get("Content-Type")
-			}
+			contentType := header.Get("Content-Type")
 			actualContentType, err := parseProtobufBody(allowLegacyBinaryFallback, contentType, buf, bodyPtrMessage)
 			if err != nil {
 				return "", err

--- a/json_transport.go
+++ b/json_transport.go
@@ -553,12 +553,15 @@ func writeQueryHeaderCookie(ctx context.Context, w io.Writer, objPtr interface{}
 		if !ok {
 			panic("protobuf field is not of type proto.Message")
 		}
-		if requestIsJSON(ctx) {
+		// requestIsJSON is only meaningful on the server, where we echo the
+		// caller's encoding. On the client (request != nil) always send
+		// binary protobuf, regardless of any ctx value inherited from an
+		// inbound handler.
+		if request == nil && requestIsJSON(ctx) {
 			jsonData, err := protojson.Marshal(bodyPtrMessage)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal protobuf as JSON: %w", err)
 			}
-			// Content-Type already set to application/json above.
 			_, err = w.Write(jsonData)
 			return nil, err
 		}

--- a/json_transport_test.go
+++ b/json_transport_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -823,6 +824,95 @@ func TestReadQueryHeaderCookieRejectsMislabeledBinaryProtobufInStrictMode(t *tes
 	got := &protobufBody{}
 	if _, err := readQueryHeaderCookie(false, got, io.NopCloser(bytes.NewReader(body)), nil, request, request.Header, http.StatusOK); err == nil {
 		t.Fatal("readQueryHeaderCookie unexpectedly succeeded in strict mode")
+	}
+}
+
+func TestParseProtobufBody(t *testing.T) {
+	sample := timestamppb.New(time.Date(2020, time.July, 10, 11, 30, 0, 0, time.UTC))
+	protoBytes, err := proto.Marshal(sample)
+	if err != nil {
+		t.Fatalf("proto.Marshal failed: %v", err)
+	}
+	jsonBytes, err := protojson.Marshal(sample)
+	if err != nil {
+		t.Fatalf("protojson.Marshal failed: %v", err)
+	}
+
+	cases := []struct {
+		name            string
+		allowLegacy     bool
+		contentType     string
+		body            []byte
+		wantContentType string
+		wantErr         bool
+	}{
+		{
+			name:            "application/json decodes as protojson",
+			contentType:     "application/json",
+			body:            jsonBytes,
+			wantContentType: "application/json",
+		},
+		{
+			name:            "application/json with charset decodes as protojson",
+			contentType:     "application/json; charset=UTF-8",
+			body:            jsonBytes,
+			wantContentType: "application/json; charset=UTF-8",
+		},
+		{
+			name:            "application/x-protobuf decodes as binary protobuf",
+			contentType:     "application/x-protobuf",
+			body:            protoBytes,
+			wantContentType: "application/x-protobuf",
+		},
+		{
+			name:            "empty content type decodes as binary protobuf",
+			contentType:     "",
+			body:            protoBytes,
+			wantContentType: "",
+		},
+		{
+			name:            "legacy fallback decodes mislabeled binary as protobuf",
+			allowLegacy:     true,
+			contentType:     "application/json",
+			body:            protoBytes,
+			wantContentType: "application/x-protobuf",
+		},
+		{
+			name:        "strict mode rejects mislabeled binary",
+			allowLegacy: false,
+			contentType: "application/json",
+			body:        protoBytes,
+			wantErr:     true,
+		},
+		{
+			name:        "legacy fallback on empty JSON body fails",
+			allowLegacy: true,
+			contentType: "application/json",
+			body:        []byte{},
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := &timestamppb.Timestamp{}
+			actual, err := parseProtobufBody(tc.allowLegacy, tc.contentType, tc.body, got)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (actualContentType=%q)", actual)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != tc.wantContentType {
+				t.Errorf("actualContentType = %q, want %q", actual, tc.wantContentType)
+			}
+			if !proto.Equal(got, sample) {
+				t.Errorf("decoded = %v, want %v", got, sample)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a cross-service decoding failure seen in dataflow (`endpointactions.AlertMatch` → `endpoint-status`), where the client received `proto: cannot parse invalid wire-format data` when the server replied with `application/json`.

Three commits:

1. **Fix: read Content-Type from the `header` parameter, not from `*http.Request`.** `readQueryHeaderCookie` is called from both the server (decoding a request, passes `r.Header`) and the client (decoding a response, passes `res.Header`). It was reading Content-Type off the `request` parameter, which is nil on the client path — so client response decoding always fell through to `proto.Unmarshal`, even when the server replied with protojson (`application/json`). Reading from `header` works on both paths. This commit alone fixes `AlertMatch`.

2. **Add `parseProtobufBody` test table.** Now that the decoder sees real Content-Type values, pin the decoder matrix:
   - `application/json` → protojson (with and without charset)
   - `application/x-protobuf` → binary protobuf
   - empty Content-Type → binary protobuf (fallthrough)
   - legacy fallback recovers mislabeled binary bodies
   - strict mode rejects mislabeled binary bodies
   - legacy fallback on empty JSON body still errors

3. **Only echo request encoding on the server; clients always emit binary proto.** `writeQueryHeaderCookie` chose between `protojson.Marshal` and `proto.Marshal` using `requestIsJSON(ctx)`. That's correct server-side (echo the caller's encoding) but wrong client-side: a context propagated from an inbound JSON handler made outbound protobuf client calls emit protojson, producing cross-service decoding failures. `request != nil` is the reliable "am I encoding an outbound client request?" signal (`EncodeRequest` passes non-nil; `EncodeResponse` passes nil).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full suite passes
- [x] `go test -run TestParseProtobufBody -v .` — new table passes (7 cases)
- [ ] Verify the fix in dataflow by rebuilding `endpoint-status` and `endpointactions` against this api2 version and reproducing the prior `AlertMatch` flow.