### PR TITLE
fix: ts:"-" fields now appear in OpenAPI spec

### DIFF
--- a/ts_client.go
+++ b/ts_client.go
@@ -191,7 +191,7 @@ func serializeTypeInfo(t *preparedType) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			if tag.State == typegen.Ignored || tag.State == typegen.NoInfo {
+			if tag.State == typegen.Ignored || tag.State == typegen.TsIgnored || tag.State == typegen.NoInfo {
 				continue
 			}
 			name := ft.Name

--- a/typegen/parse.go
+++ b/typegen/parse.go
@@ -164,13 +164,20 @@ func (this *Parser) visitType(t reflect.Type) {
 		}
 		record := &RecordDef{}
 		record.Name = unrefT.Name()
-		var astFields []*ast.Field
+		var astFieldByName map[string]*ast.Field
 		// if we parse anonymous struct doc is not available
 		if record.Name != "" {
-			recordDoc, f := getFieldsAst(unrefT)
+			recordDoc, astFields := getFieldsAst(unrefT)
 			if recordDoc != nil {
-				astFields = f
 				record.Doc = FormatDoc(recordDoc.Doc)
+				// go/doc excludes unexported fields, so use name-based lookup
+				// to avoid index mismatch with reflect (e.g. protobuf state fields)
+				astFieldByName = make(map[string]*ast.Field, len(astFields))
+				for _, f := range astFields {
+					for _, name := range f.Names {
+						astFieldByName[name.Name] = f
+					}
+				}
 			}
 		}
 		record.T = unrefT
@@ -185,8 +192,8 @@ func (this *Parser) visitType(t reflect.Type) {
 				Type:  indirect(structFieldType),
 				IsRef: structFieldType != structField.Type,
 			}
-			if record.Name != "" && astFields != nil && len(astFields) > i {
-				field.Doc = FormatDoc(astFields[i].Comment.Text())
+			if af, ok := astFieldByName[structField.Name]; ok {
+				field.Doc = FormatDoc(af.Comment.Text())
 			}
 			isEmbed := structField.Anonymous && k == reflect.Struct
 			parseResult, err := ParseStructTag(structField.Tag)

--- a/typegen/parse.go
+++ b/typegen/parse.go
@@ -8,9 +8,11 @@ import (
 )
 
 type Parser struct {
-	rawTypes   []reflect.Type
-	seen       map[reflect.Type]IType
-	visitOrder []reflect.Type
+	rawTypes    []reflect.Type
+	seen        map[reflect.Type]IType
+	tsVisible   map[reflect.Type]bool
+	visitOrder  []reflect.Type
+	inTsIgnored bool
 	// You can skip field or replace it with another type
 	CustomParse func(arg reflect.Type) (IType, bool)
 }
@@ -18,6 +20,7 @@ type Parser struct {
 func NewFromTypes(types ...interface{}) *Parser {
 	p := &Parser{}
 	p.seen = make(map[reflect.Type]IType)
+	p.tsVisible = make(map[reflect.Type]bool)
 	for _, rawType := range types {
 		p.rawTypes = append(p.rawTypes, parseType(rawType))
 	}
@@ -29,6 +32,7 @@ func NewFromTypes(types ...interface{}) *Parser {
 func NewParser(types ...RawType) *Parser {
 	p := &Parser{}
 	p.seen = make(map[reflect.Type]IType)
+	p.tsVisible = make(map[reflect.Type]bool)
 	return p
 }
 
@@ -76,6 +80,42 @@ func (this *Parser) isVisited(t reflect.Type) bool {
 	return this.seen[t] != nil
 }
 
+func (this *Parser) IsTsVisible(t reflect.Type) bool {
+	return this.tsVisible[indirect(t)]
+}
+
+// propagateTsVisible marks t and all types reachable from it (excluding
+// TsIgnored-field subtrees) as TypeScript-visible.
+func (this *Parser) propagateTsVisible(t reflect.Type) {
+	if this.tsVisible[t] {
+		return
+	}
+	this.tsVisible[t] = true
+	itype := this.seen[t]
+	switch v := itype.(type) {
+	case *RecordDef:
+		for _, f := range v.Fields {
+			if f.Tag != nil && f.Tag.State == TsIgnored {
+				continue
+			}
+			if f.Type != nil {
+				this.propagateTsVisible(indirect(f.Type))
+			}
+		}
+		for _, e := range v.Embedded {
+			this.propagateTsVisible(indirect(e))
+		}
+	case *TypeDef:
+		elem := v.T
+		if elem.Kind() == reflect.Slice || elem.Kind() == reflect.Array {
+			this.propagateTsVisible(indirect(elem.Elem()))
+		} else if elem.Kind() == reflect.Map {
+			this.propagateTsVisible(indirect(elem.Key()))
+			this.propagateTsVisible(indirect(elem.Elem()))
+		}
+	}
+}
+
 var re = regexp.MustCompile(`[\n\t\r]+`)
 
 func FormatDoc(str string) string {
@@ -94,16 +134,27 @@ func (this *Parser) visitType(t reflect.Type) {
 	unrefT := indirect(t)
 	k := unrefT.Kind()
 	if this.isVisited(unrefT) {
+		// If we now need to promote this type to tsVisible, propagate.
+		if !this.inTsIgnored && !this.tsVisible[unrefT] {
+			this.propagateTsVisible(unrefT)
+		}
 		return
 	}
 	if this.CustomParse != nil {
 		v, skip := this.CustomParse(unrefT)
 		if !skip && v != nil {
 			this.markVisit(unrefT, v)
+			if !this.inTsIgnored {
+				this.tsVisible[unrefT] = true
+			}
 			return
 		} else if skip {
 			return
 		}
+	}
+
+	if !this.inTsIgnored {
+		this.tsVisible[unrefT] = true
 	}
 
 	switch {
@@ -147,6 +198,23 @@ func (this *Parser) visitType(t reflect.Type) {
 			if parseResult.FieldType != "" {
 				// we should not parse field type if we set it manually
 				field.Type = nil
+				record.Fields = append(record.Fields, field)
+				continue
+			}
+			if parseResult.State == TsIgnored {
+				// Visit for Swagger (needed for $ref resolution) but not for TypeScript.
+				prev := this.inTsIgnored
+				this.inTsIgnored = true
+				this.visitType(structFieldType)
+				this.inTsIgnored = prev
+				// if struct type has no name it means it's anonymous so we set field value afterwards
+				if structFieldType.Name() == "" && structFieldType.Kind() == reflect.Struct {
+					this.GetVisited(structFieldType).SetName(record.Name+"_"+field.Key, unrefT.PkgPath())
+				}
+				if structField.Anonymous && k == reflect.Struct {
+					record.Embedded = append(record.Embedded, structFieldType)
+					continue
+				}
 				record.Fields = append(record.Fields, field)
 				continue
 			}

--- a/typegen/tests/ts_ignored_test.go
+++ b/typegen/tests/ts_ignored_test.go
@@ -1,0 +1,46 @@
+package typegen
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+
+	gots "github.com/starius/api2/typegen"
+	"github.com/starius/api2/typegen/tests/types"
+
+	spec "github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestTsIgnoredField_absentFromTypeScript(t *testing.T) {
+	p := gots.NewFromTypes(&types.WithTsIgnoredField{})
+	var buf bytes.Buffer
+	gots.PrintTsTypes(p, &buf, func(t reflect.Type) string { return "" })
+	output := buf.String()
+	if strings.Contains(output, "internal") {
+		t.Errorf("expected 'internal' field to be absent from TypeScript output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "name") {
+		t.Errorf("expected 'name' field to be present in TypeScript output, got:\n%s", output)
+	}
+}
+
+func TestTsIgnoredField_presentInSwagger(t *testing.T) {
+	p := gots.NewFromTypes(&types.WithTsIgnoredField{})
+	swag := &spec.T{
+		Components: &spec.Components{},
+	}
+	gots.PrintSwagger(p, swag)
+
+	typeName := "types.WithTsIgnoredField"
+	schema, ok := swag.Components.Schemas[typeName]
+	if !ok {
+		t.Fatalf("schema %q not found in Swagger output", typeName)
+	}
+	if _, hasInternal := schema.Value.Properties["internal"]; !hasInternal {
+		t.Errorf("expected 'internal' field to be present in Swagger schema, got properties: %v", schema.Value.Properties)
+	}
+	if _, hasName := schema.Value.Properties["name"]; !hasName {
+		t.Errorf("expected 'name' field to be present in Swagger schema")
+	}
+}

--- a/typegen/tests/ts_ignored_test.go
+++ b/typegen/tests/ts_ignored_test.go
@@ -25,6 +25,48 @@ func TestTsIgnoredField_absentFromTypeScript(t *testing.T) {
 	}
 }
 
+func TestTsIgnoredComplexField_subtypeAbsentFromTypeScript(t *testing.T) {
+	p := gots.NewFromTypes(&types.WithTsIgnoredComplexField{})
+	var buf bytes.Buffer
+	gots.PrintTsTypes(p, &buf, func(t reflect.Type) string { return "" })
+	output := buf.String()
+	if strings.Contains(output, "InternalDetail") {
+		t.Errorf("expected 'InternalDetail' type to be absent from TypeScript output, got:\n%s", output)
+	}
+	if strings.Contains(output, "InternalStatus") {
+		t.Errorf("expected 'InternalStatus' enum to be absent from TypeScript output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "name") {
+		t.Errorf("expected 'name' field to be present in TypeScript output, got:\n%s", output)
+	}
+}
+
+func TestTsIgnoredComplexField_subtypePresentInSwagger(t *testing.T) {
+	p := gots.NewFromTypes(&types.WithTsIgnoredComplexField{})
+	swag := &spec.T{
+		Components: &spec.Components{},
+	}
+	gots.PrintSwagger(p, swag)
+
+	typeName := "types.WithTsIgnoredComplexField"
+	schema, ok := swag.Components.Schemas[typeName]
+	if !ok {
+		t.Fatalf("schema %q not found in Swagger output", typeName)
+	}
+	if _, hasDetail := schema.Value.Properties["detail"]; !hasDetail {
+		t.Errorf("expected 'detail' field to be present in Swagger schema, got properties: %v", schema.Value.Properties)
+	}
+	detailSchema, hasDetail := swag.Components.Schemas["types.InternalDetail"]
+	if !hasDetail {
+		t.Errorf("expected 'InternalDetail' type to be present in Swagger schemas")
+	}
+	if detailSchema != nil {
+		if _, hasStatus := detailSchema.Value.Properties["status"]; !hasStatus {
+			t.Errorf("expected 'status' field in InternalDetail Swagger schema")
+		}
+	}
+}
+
 func TestTsIgnoredField_presentInSwagger(t *testing.T) {
 	p := gots.NewFromTypes(&types.WithTsIgnoredField{})
 	swag := &spec.T{

--- a/typegen/tests/types/types.go
+++ b/typegen/tests/types/types.go
@@ -60,6 +60,12 @@ type M struct {
 	Username string `json:"Username2"` // field doc
 }
 
+// WithTsIgnoredField has a field excluded from TypeScript but present on the wire.
+type WithTsIgnoredField struct {
+	Name     string `json:"name"`
+	Internal string `json:"internal" ts:"-"`
+}
+
 // user
 type User struct {
 	M

--- a/typegen/tests/types/types.go
+++ b/typegen/tests/types/types.go
@@ -60,10 +60,30 @@ type M struct {
 	Username string `json:"Username2"` // field doc
 }
 
+// InternalStatus is a type used only inside ts-ignored fields.
+type InternalStatus string
+
+const (
+	InternalStatusActive   InternalStatus = "active"
+	InternalStatusInactive InternalStatus = "inactive"
+)
+
+// InternalDetail is a struct used only inside ts-ignored fields.
+type InternalDetail struct {
+	Status InternalStatus `json:"status"`
+}
+
 // WithTsIgnoredField has a field excluded from TypeScript but present on the wire.
 type WithTsIgnoredField struct {
 	Name     string `json:"name"`
 	Internal string `json:"internal" ts:"-"`
+}
+
+// WithTsIgnoredComplexField has a ts-ignored field whose type has subtypes.
+// Those subtypes should NOT appear in TypeScript output.
+type WithTsIgnoredComplexField struct {
+	Name   string         `json:"name"`
+	Detail *InternalDetail `json:"detail,omitempty" ts:"-"`
 }
 
 // user

--- a/typegen/typescript.printer.go
+++ b/typegen/typescript.printer.go
@@ -154,7 +154,14 @@ func PrintTsTypes(parser *Parser, w io.Writer, stringify Stringifier, opts ...Ts
 		}).Parse(RecordTemplate)
 		panicIf(err)
 		w := &bytes.Buffer{}
-		err = tmpl.Execute(w, r)
+		visible := *r
+		visible.Fields = make([]*RecordField, 0, len(r.Fields))
+		for _, f := range r.Fields {
+			if f.Tag.State != TsIgnored {
+				visible.Fields = append(visible.Fields, f)
+			}
+		}
+		err = tmpl.Execute(w, &visible)
 		panicIf(err)
 		return w.String()
 	}

--- a/typegen/typescript.printer.go
+++ b/typegen/typescript.printer.go
@@ -109,6 +109,9 @@ func PrintTsTypes(parser *Parser, w io.Writer, stringify Stringifier, opts ...Ts
 	output := make(map[string][]IType)
 
 	for _, m := range parser.visitOrder {
+		if !parser.IsTsVisible(m) {
+			continue
+		}
 		pkg := parser.seen[m].GetPackage()
 		output[path.Base(pkg)] = append(output[path.Base(pkg)], parser.seen[m])
 	}

--- a/typegen/util.go
+++ b/typegen/util.go
@@ -107,7 +107,7 @@ func ParseStructTag(structTag reflect.StructTag) (*ParseResult, error) {
 		case "optional":
 			result.State = Optional
 		}
-		if jsonTagOption == "omitempty" {
+		if jsonTagOption == "omitempty" && result.State != TsIgnored {
 			result.State = Optional
 		}
 		if result.FieldName == "" {

--- a/typegen/util.go
+++ b/typegen/util.go
@@ -90,8 +90,11 @@ func ParseStructTag(structTag reflect.StructTag) (*ParseResult, error) {
 		}
 		if result.FieldName == "" {
 			result.FieldName = headerTagVal
-			// Set header as optional in case you want to set it in implicit way.
-			result.State = Optional
+			// Set header as optional in case you want to set it in implicit way,
+			// but don't override TsIgnored state.
+			if result.State != TsIgnored {
+				result.State = Optional
+			}
 		}
 		if result.FieldName == "" {
 			result.FieldName = queryTagVal

--- a/typegen/util.go
+++ b/typegen/util.go
@@ -44,6 +44,7 @@ type PropertyState int
 const (
 	Auto PropertyState = iota
 	Ignored
+	TsIgnored // ts:"-": field is on the wire but excluded from TypeScript output only
 	Optional
 	Null
 	NotNull
@@ -76,13 +77,17 @@ func ParseStructTag(structTag reflect.StructTag) (*ParseResult, error) {
 		tsTagVal, tsTagOptions    = parseJsonLikeTag(structTag.Get("ts"))
 	)
 
-	if jsonTagVal == "-" || tsTagVal == "-" {
+	if jsonTagVal == "-" {
 		result.State = Ignored
+	} else if tsTagVal == "-" {
+		result.State = TsIgnored
 	}
 
 	if result.State != Ignored {
 		result.FieldName = jsonTagVal
-		result.FieldType = tsTagVal
+		if tsTagVal != "-" {
+			result.FieldType = tsTagVal
+		}
 		if result.FieldName == "" {
 			result.FieldName = headerTagVal
 			// Set header as optional in case you want to set it in implicit way.

--- a/typegen/util_test.go
+++ b/typegen/util_test.go
@@ -1,0 +1,34 @@
+package typegen
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseStructTag_tsIgnored(t *testing.T) {
+	type testStruct struct {
+		Hidden string `json:"hidden" ts:"-"`
+	}
+	field, _ := reflect.TypeOf(testStruct{}).FieldByName("Hidden")
+	result, err := ParseStructTag(field.Tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != TsIgnored {
+		t.Errorf("expected TsIgnored, got %v", result.State)
+	}
+}
+
+func TestParseStructTag_jsonIgnored(t *testing.T) {
+	type testStruct struct {
+		Hidden string `json:"-"`
+	}
+	field, _ := reflect.TypeOf(testStruct{}).FieldByName("Hidden")
+	result, err := ParseStructTag(field.Tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != Ignored {
+		t.Errorf("expected Ignored, got %v", result.State)
+	}
+}

--- a/typegen/util_test.go
+++ b/typegen/util_test.go
@@ -19,6 +19,23 @@ func TestParseStructTag_tsIgnored(t *testing.T) {
 	}
 }
 
+func TestParseStructTag_tsIgnoredWithHeader(t *testing.T) {
+	type testStruct struct {
+		RequestID string `header:"X-Request-Id" ts:"-"`
+	}
+	field, _ := reflect.TypeOf(testStruct{}).FieldByName("RequestID")
+	result, err := ParseStructTag(field.Tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != TsIgnored {
+		t.Errorf("expected TsIgnored, got %v", result.State)
+	}
+	if result.FieldName != "X-Request-Id" {
+		t.Errorf("expected FieldName X-Request-Id, got %q", result.FieldName)
+	}
+}
+
 func TestParseStructTag_jsonIgnored(t *testing.T) {
 	type testStruct struct {
 		Hidden string `json:"-"`

--- a/typegen/util_test.go
+++ b/typegen/util_test.go
@@ -19,6 +19,20 @@ func TestParseStructTag_tsIgnored(t *testing.T) {
 	}
 }
 
+func TestParseStructTag_tsIgnoredWithOmitempty(t *testing.T) {
+	type testStruct struct {
+		LastModified string `json:"last_modified,omitempty" ts:"-"`
+	}
+	field, _ := reflect.TypeOf(testStruct{}).FieldByName("LastModified")
+	result, err := ParseStructTag(field.Tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != TsIgnored {
+		t.Errorf("expected TsIgnored, got %v", result.State)
+	}
+}
+
 func TestParseStructTag_tsIgnoredWithHeader(t *testing.T) {
 	type testStruct struct {
 		RequestID string `header:"X-Request-Id" ts:"-"`


### PR DESCRIPTION
## Summary

- `ts:"-"` and `json:"-"` previously both mapped to `Ignored` state, causing `ts:"-"` fields to be silently dropped from the OpenAPI spec even though they are present on the wire
- Added a distinct `TsIgnored` state so the shared parser retains these fields; the TypeScript printer filters them at render time, the Swagger printer sees them unchanged
- `json:"-"` behavior is unchanged — those fields are still excluded everywhere

## Test Plan

- [x] Unit tests for `ParseStructTag` asserting `ts:"-"` → `TsIgnored` and `json:"-"` → `Ignored`
- [x] Integration test asserting a `ts:"-"` field is absent from TypeScript output
- [x] Integration test asserting a `ts:"-"` field is present in Swagger/OpenAPI output
- [x] Full test suite passes (184 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)