### PR TITLE
Fix remaining ts:"-" TypeScript exclusion edge cases

### DIFF
--- a/typegen/Readme.md
+++ b/typegen/Readme.md
@@ -52,4 +52,6 @@ tsTag[0] = "string"|"date"|"-"
 tsTag[1] = "optional"|"no-null"|"null"
 ```
 
+Use `ts:"-"` for fields that remain part of the wire/OpenAPI schema but should be omitted from generated TypeScript types.
+
 see field.go for more info

--- a/typegen/parse.go
+++ b/typegen/parse.go
@@ -156,6 +156,7 @@ func (this *Parser) visitType(t reflect.Type) {
 				this.GetVisited(structFieldType).SetName(record.Name+"_"+field.Key, unrefT.PkgPath())
 			}
 			if structField.Anonymous && k == reflect.Struct {
+				record.EmbeddedFields = append(record.EmbeddedFields, field)
 				record.Embedded = append(record.Embedded, structFieldType)
 				continue
 			}

--- a/typegen/record.go
+++ b/typegen/record.go
@@ -31,8 +31,11 @@ type TypeDef struct {
 
 type RecordDef struct {
 	BaseType
-	Fields   []*RecordField
-	Embedded []reflect.Type
+	Fields []*RecordField
+	// EmbeddedFields keeps tag state for embedded fields so ts:"-" embeds can
+	// stay in schema output without leaking into generated TypeScript.
+	EmbeddedFields []*RecordField
+	Embedded       []reflect.Type
 }
 
 type EnumDef struct {

--- a/typegen/tests/ts_ignored_test.go
+++ b/typegen/tests/ts_ignored_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/starius/api2/typegen/tests/types"
 
 	spec "github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTsIgnoredField_absentFromTypeScript(t *testing.T) {
@@ -23,6 +24,26 @@ func TestTsIgnoredField_absentFromTypeScript(t *testing.T) {
 	if !strings.Contains(output, "name") {
 		t.Errorf("expected 'name' field to be present in TypeScript output, got:\n%s", output)
 	}
+}
+
+func TestTsIgnoredFieldType_absentFromTypeScript(t *testing.T) {
+	p := gots.NewFromTypes(&types.WithTsIgnoredObject{})
+	var buf bytes.Buffer
+	gots.PrintTsTypes(p, &buf, func(t reflect.Type) string { return "" })
+	output := buf.String()
+	require.NotContains(t, output, "TsHiddenPayload")
+	require.NotContains(t, output, "internal")
+	require.Contains(t, output, "name")
+}
+
+func TestTsIgnoredEmbedded_absentFromTypeScript(t *testing.T) {
+	p := gots.NewFromTypes(&types.WithTsIgnoredEmbedded{})
+	var buf bytes.Buffer
+	gots.PrintTsTypes(p, &buf, func(t reflect.Type) string { return "" })
+	output := buf.String()
+	require.NotContains(t, output, "TsHiddenEmbedded")
+	require.NotContains(t, output, "secret")
+	require.Contains(t, output, "name")
 }
 
 func TestTsIgnoredField_presentInSwagger(t *testing.T) {

--- a/typegen/tests/types/types.go
+++ b/typegen/tests/types/types.go
@@ -66,6 +66,24 @@ type WithTsIgnoredField struct {
 	Internal string `json:"internal" ts:"-"`
 }
 
+type TsHiddenPayload struct {
+	Secret string `json:"secret"`
+}
+
+type WithTsIgnoredObject struct {
+	Name     string          `json:"name"`
+	Internal TsHiddenPayload `json:"internal" ts:"-"`
+}
+
+type TsHiddenEmbedded struct {
+	Secret string `json:"secret"`
+}
+
+type WithTsIgnoredEmbedded struct {
+	Name             string `json:"name"`
+	TsHiddenEmbedded `ts:"-"`
+}
+
 // user
 type User struct {
 	M

--- a/typegen/typescript.printer.go
+++ b/typegen/typescript.printer.go
@@ -88,6 +88,92 @@ func EnumsWithPrefix(value bool) TsTypesOption {
 	}
 }
 
+func isTsIgnoredField(field *RecordField) bool {
+	return field != nil && field.Tag != nil && field.Tag.State == TsIgnored
+}
+
+func tsVisibleFields(r *RecordDef) []*RecordField {
+	fields := make([]*RecordField, 0, len(r.Fields))
+	for _, f := range r.Fields {
+		if !isTsIgnoredField(f) {
+			fields = append(fields, f)
+		}
+	}
+	return fields
+}
+
+func tsVisibleEmbedded(r *RecordDef) []reflect.Type {
+	if len(r.EmbeddedFields) != len(r.Embedded) {
+		return r.Embedded
+	}
+	embedded := make([]reflect.Type, 0, len(r.EmbeddedFields))
+	for _, f := range r.EmbeddedFields {
+		if !isTsIgnoredField(f) && f.Type != nil {
+			embedded = append(embedded, f.Type)
+		}
+	}
+	return embedded
+}
+
+func tsVisibleTypes(parser *Parser) map[reflect.Type]bool {
+	visible := make(map[reflect.Type]bool)
+	if len(parser.rawTypes) == 0 {
+		for _, t := range parser.visitOrder {
+			visible[t] = true
+		}
+		return visible
+	}
+
+	var markRef func(t reflect.Type)
+	var markVisited func(t reflect.Type)
+
+	markVisited = func(t reflect.Type) {
+		t = indirect(t)
+		if visible[t] {
+			return
+		}
+		visited := parser.GetVisited(t)
+		if visited == nil {
+			return
+		}
+		visible[t] = true
+
+		switch v := visited.(type) {
+		case *RecordDef:
+			for _, embedded := range tsVisibleEmbedded(v) {
+				markRef(embedded)
+			}
+			for _, field := range tsVisibleFields(v) {
+				markRef(field.Type)
+			}
+		case *TypeDef:
+			markRef(v.T)
+		}
+	}
+
+	markRef = func(t reflect.Type) {
+		if t == nil {
+			return
+		}
+		t = indirect(t)
+		markVisited(t)
+		switch t.Kind() {
+		case reflect.Slice, reflect.Array:
+			markRef(t.Elem())
+		case reflect.Map:
+			markRef(t.Key())
+			markRef(t.Elem())
+		}
+	}
+
+	// ts:"-" fields remain in parser state for OpenAPI, so TypeScript needs a
+	// reachable set that follows only TS-visible fields from the requested roots.
+	for _, t := range parser.rawTypes {
+		markRef(t)
+	}
+	return visible
+}
+
 func PrintTsTypes(parser *Parser, w io.Writer, stringify Stringifier, opts ...TsTypesOption) {
 	var config TsTypesConfig
 	for _, opt := range opts {
@@ -107,8 +193,12 @@ func PrintTsTypes(parser *Parser, w io.Writer, stringify Stringifier, opts ...Ts
 		stringify = stringifyCustom
 	}
 	output := make(map[string][]IType)
+	visibleTypes := tsVisibleTypes(parser)
 
 	for _, m := range parser.visitOrder {
+		if !visibleTypes[m] {
+			continue
+		}
 		pkg := parser.seen[m].GetPackage()
 		output[path.Base(pkg)] = append(output[path.Base(pkg)], parser.seen[m])
 	}
@@ -155,12 +245,8 @@ func PrintTsTypes(parser *Parser, w io.Writer, stringify Stringifier, opts ...Ts
 		panicIf(err)
 		w := &bytes.Buffer{}
 		visible := *r
-		visible.Fields = make([]*RecordField, 0, len(r.Fields))
-		for _, f := range r.Fields {
-			if f.Tag.State != TsIgnored {
-				visible.Fields = append(visible.Fields, f)
-			}
-		}
+		visible.Fields = tsVisibleFields(r)
+		visible.Embedded = tsVisibleEmbedded(r)
 		err = tmpl.Execute(w, &visible)
 		panicIf(err)
 		return w.String()

--- a/typegen/util.go
+++ b/typegen/util.go
@@ -99,19 +99,21 @@ func ParseStructTag(structTag reflect.StructTag) (*ParseResult, error) {
 		if result.FieldName == "" {
 			result.FieldName = queryTagVal
 		}
-		switch tsTagOptions {
-		case "no-null":
-			result.State = NotNull
-		case "null":
-			result.State = Null
-		case "optional":
-			result.State = Optional
-		}
-		if jsonTagOption == "omitempty" {
-			result.State = Optional
-		}
-		if result.FieldName == "" {
-			result.State = NoInfo
+		if result.State != TsIgnored {
+			switch tsTagOptions {
+			case "no-null":
+				result.State = NotNull
+			case "null":
+				result.State = Null
+			case "optional":
+				result.State = Optional
+			}
+			if jsonTagOption == "omitempty" {
+				result.State = Optional
+			}
+			if result.FieldName == "" {
+				result.State = NoInfo
+			}
 		}
 	}
 	return result, nil

--- a/typegen/util_test.go
+++ b/typegen/util_test.go
@@ -3,6 +3,8 @@ package typegen
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseStructTag_tsIgnored(t *testing.T) {
@@ -34,6 +36,37 @@ func TestParseStructTag_tsIgnoredWithHeader(t *testing.T) {
 	if result.FieldName != "X-Request-Id" {
 		t.Errorf("expected FieldName X-Request-Id, got %q", result.FieldName)
 	}
+}
+
+func TestParseStructTag_tsIgnoredWithJsonOmitEmpty(t *testing.T) {
+	type testStruct struct {
+		Hidden string `json:"hidden,omitempty" ts:"-"`
+	}
+	field, _ := reflect.TypeOf(testStruct{}).FieldByName("Hidden")
+	result, err := ParseStructTag(field.Tag)
+	require.NoError(t, err)
+	require.Equal(t, TsIgnored, result.State)
+	require.Equal(t, "hidden", result.FieldName)
+}
+
+func TestParseStructTag_tsIgnoredWithTsOption(t *testing.T) {
+	type testStruct struct {
+		Hidden string `json:"hidden" ts:"-,optional"`
+	}
+	field, _ := reflect.TypeOf(testStruct{}).FieldByName("Hidden")
+	result, err := ParseStructTag(field.Tag)
+	require.NoError(t, err)
+	require.Equal(t, TsIgnored, result.State)
+}
+
+func TestParseStructTag_tsIgnoredWithoutWireName(t *testing.T) {
+	type testStruct struct {
+		Hidden string `ts:"-"`
+	}
+	field, _ := reflect.TypeOf(testStruct{}).FieldByName("Hidden")
+	result, err := ParseStructTag(field.Tag)
+	require.NoError(t, err)
+	require.Equal(t, TsIgnored, result.State)
 }
 
 func TestParseStructTag_jsonIgnored(t *testing.T) {


### PR DESCRIPTION
Hi, I noticed you opened a [PR](https://github.com/starius/api2/pull/69) to split `ts:"-"` behavior between TypeScript output and OpenAPI schema generation, and I decided to build on it by covering the remaining edge cases around that contract.

This PR keeps `ts:"-"` fields available to the parser and OpenAPI printer, while making the TypeScript printer consistently omit them.

Changes:

- Keep `TsIgnored` sticky when later tag modifiers are parsed, so `json:",omitempty"`, `ts:"-,optional"`, and fields without a wire name do not accidentally become TypeScript-visible again.
- Track tag metadata for embedded fields, allowing embedded `ts:"-"` fields to remain in schema output without leaking into TypeScript intersections.
- Render TypeScript declarations from the TS-visible graph only, so named types reachable exclusively through hidden fields are not emitted.
- Add regression coverage for parser precedence, hidden nested field types, and hidden embedded fields.
- Clarify the docs that `ts:"-"` hides generated TypeScript only; it does not remove the field from the wire/OpenAPI schema.

### How to verify the changes?

Revert each fix commit confirm the code still builds while the paired regression tests fail with symptomatic errors.

Reverting `fix: keep ts exclusion sticky across tag modifiers` still builds, but the parser regression tests fail because `TsIgnored` is overwritten by later tag state.

<details>
<summary>Regression failure when parser-state fix is removed</summary>

```text
--- FAIL: TestParseStructTag_tsIgnoredWithJsonOmitEmpty (0.00s)
    util_test.go:48:
        	Error Trace:	util_test.go:48
        	Error:      	Not equal:
        	            	expected: 2
        	            	actual  : 3
        	Test:       	TestParseStructTag_tsIgnoredWithJsonOmitEmpty
--- FAIL: TestParseStructTag_tsIgnoredWithTsOption (0.00s)
    util_test.go:59:
        	Error Trace:	util_test.go:59
        	Error:      	Not equal:
        	            	expected: 2
        	            	actual  : 3
        	Test:       	TestParseStructTag_tsIgnoredWithTsOption
--- FAIL: TestParseStructTag_tsIgnoredWithoutWireName (0.00s)
    util_test.go:69:
        	Error Trace:	util_test.go:69
        	Error:      	Not equal:
        	            	expected: 2
        	            	actual  : 6
        	Test:       	TestParseStructTag_tsIgnoredWithoutWireName
FAIL
FAIL	github.com/starius/api2/typegen
```

</details>

Reverting `fix: prune TypeScript graph after ts exclusions` still builds, but the TypeScript regression tests fail because hidden-only declarations and embedded intersections leak back into generated output:

<details>
<summary>Regression failure when TypeScript graph-pruning fix is removed</summary>


```text
--- FAIL: TestTsIgnoredFieldType_absentFromTypeScript (0.09s)
    ts_ignored_test.go:34:
        	Error Trace:	ts_ignored_test.go:34
        	Error:      	"\nexport declare namespace types {\n\nexport type WithTsIgnoredObject = {\n\tname: string\n}\n\n\nexport type TsHiddenPayload = {\n\tsecret: string\n}\n\n}\n" should not contain "TsHiddenPayload"
        	Test:       	TestTsIgnoredFieldType_absentFromTypeScript
--- FAIL: TestTsIgnoredEmbedded_absentFromTypeScript (0.00s)
    ts_ignored_test.go:44:
        	Error Trace:	ts_ignored_test.go:44
        	Error:      	"\nexport declare namespace types {\n\nexport type WithTsIgnoredEmbedded =  types.TsHiddenEmbedded & {\n\tname: string\n}\n\n\nexport type TsHiddenEmbedded = {\n\tsecret: string\n}\n\n}\n" should not contain "TsHiddenEmbedded"
        	Test:       	TestTsIgnoredEmbedded_absentFromTypeScript
FAIL
FAIL	github.com/starius/api2/typegen/tests
```

</details>


🤖 Assisted-by: OpenAI GPT-5