### PR TITLE
DDR-35498 collapse multi-line godoc on enum and named slice types

### DIFF
--- a/typegen/parse.go
+++ b/typegen/parse.go
@@ -246,7 +246,7 @@ func (this *Parser) visitType(t reflect.Type) {
 			b := &TypeDef{}
 			b.Name = unrefT.Name()
 			b.T = unrefT
-			b.Doc = getDoc(unrefT).Doc
+			b.Doc = FormatDoc(getDoc(unrefT).Doc)
 			this.markVisit(unrefT, b)
 		}
 	case (isNumber(k) || k == reflect.String) && isEnum(unrefT):
@@ -255,7 +255,7 @@ func (this *Parser) visitType(t reflect.Type) {
 			this.markVisit(unrefT, enum)
 			enum.T = unrefT
 			if getDoc(unrefT) != nil {
-				enum.Doc = getDoc(unrefT).Doc
+				enum.Doc = FormatDoc(getDoc(unrefT).Doc)
 			}
 			enum.Values = getTypedEnumValues(t)
 			enum.Name = unrefT.Name()

--- a/typegen/tests/multiline_doc_test.go
+++ b/typegen/tests/multiline_doc_test.go
@@ -1,0 +1,38 @@
+package typegen
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+
+	gots "github.com/starius/api2/typegen"
+	"github.com/starius/api2/typegen/tests/types"
+)
+
+// Multi-line godoc on an enum or named slice type must not leak continuation
+// lines into gen.ts uncommented (the printer prefixes `// ` only once).
+func TestMultilineDoc_enum_collapsed(t *testing.T) {
+	assertNoUncommentedContinuation(t, reflect.TypeOf(types.MultilineEnum("")), "MultilineEnum")
+}
+
+func TestMultilineDoc_namedSlice_collapsed(t *testing.T) {
+	assertNoUncommentedContinuation(t, reflect.TypeOf(types.MultilineArray{}), "MultilineArray")
+}
+
+func assertNoUncommentedContinuation(t *testing.T, seed reflect.Type, typeName string) {
+	t.Helper()
+	p := gots.NewFromTypes(seed)
+	var buf bytes.Buffer
+	gots.PrintTsTypes(p, &buf, func(t reflect.Type) string { return "" })
+	out := buf.String()
+	if !strings.Contains(out, typeName) {
+		t.Fatalf("expected %q in output, got:\n%s", typeName, out)
+	}
+	needle := "The second line must not land uncommented in gen.ts."
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, needle) && !strings.HasPrefix(strings.TrimSpace(line), "//") {
+			t.Fatalf("continuation line leaked uncommented into TypeScript output:\n%s", out)
+		}
+	}
+}

--- a/typegen/tests/types/types.go
+++ b/typegen/tests/types/types.go
@@ -73,6 +73,19 @@ type InternalDetail struct {
 	Status InternalStatus `json:"status"`
 }
 
+// MultilineEnum has a multi-line godoc comment.
+// The second line must not land uncommented in gen.ts.
+type MultilineEnum string
+
+const (
+	MultilineEnumA MultilineEnum = "a"
+	MultilineEnumB MultilineEnum = "b"
+)
+
+// MultilineArray has a multi-line godoc comment.
+// The second line must not land uncommented in gen.ts.
+type MultilineArray []int
+
 // WithTsIgnoredField has a field excluded from TypeScript but present on the wire.
 type WithTsIgnoredField struct {
 	Name     string `json:"name"`


### PR DESCRIPTION
## Why

The TypeScript printer template ([typegen/typescript.printer.go:18](typegen/typescript.printer.go#L18)) prefixes `//` on the first line of a type's doc and dumps the rest verbatim:

```
{{if \$type.Doc| ne ""}}// {{\$type.Doc -}}{{end}}
```

Struct docs are already normalized through `FormatDoc` ([parse.go:172](typegen/parse.go#L172)) which collapses newlines, so they render as a single `// ` line. But **enum-derived** docs ([parse.go:258](typegen/parse.go#L258)) and **named slice/array/map** docs ([parse.go:249](typegen/parse.go#L249)) were stored raw. A Go doc comment spanning multiple `//` lines therefore leaked continuation text into the generated TypeScript without a `//` prefix, breaking the file.

Real symptom seen downstream in cloud-connectors PR #4392 — a 3-line \`VMStatus\` comment on a \`type VMStatus string\` enum shipped two uncommented lines into \`frontend/gen.ts\`.

## What

Route enum and TypeDef docs through \`FormatDoc\`, matching the RecordDef path. Same behavior struct docs already had.

## Test

Added regression tests in \`typegen/tests/multiline_doc_test.go\` covering both the enum and the named-slice branch. Both fail without the fix (continuation line leaks uncommented) and pass with it. Existing tests still pass.

## Downstream

Once merged and tagged, bump the replace directive in cloud-connectors \`go.mod\` and re-run \`make frontend-gen\`.